### PR TITLE
Fix i2c control register access timing by adding a delay

### DIFF
--- a/embassy-microchip/Cargo.toml
+++ b/embassy-microchip/Cargo.toml
@@ -1,0 +1,120 @@
+[package]
+name = "embassy-microchip"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+description = "Embassy Hardware Abstraction Layer (HAL) for the MEC and CEC family of microcontrollers"
+keywords = ["embedded", "async", "microchip", "mec", "cec", "embedded-hal"]
+categories = ["embedded", "hardware-support", "no-std", "asynchronous"]
+repository = "https://github.com/embassy-rs/embassy"
+documentation = "https://docs.embassy.dev/embassy-microchip"
+
+[package.metadata.embassy_docs]
+src_base = "https://github.com/embassy-rs/embassy/blob/embassy-microchip-v$VERSION/embassy-microchip/src/"
+src_base_git = "https://github.com/embassy-rs/embassy/blob/$COMMIT/embassy-microchip/src/"
+features = ["defmt", "unstable-pac"]
+flavors = [
+    { regex_feature = ".*", target = "thumbv7em-none-eabihf" }
+]
+
+[package.metadata.docs.rs]
+features = ["mec1723n_b0_sz", "defmt", "unstable-pac", "time-driver-cct"]
+rustdoc-args = ["--cfg", "docsrs"]
+
+[features]
+default = ["rt"]
+
+## Cortex-M runtime (enabled by default)
+rt = ["mec17xx-pac/rt"]
+
+## Enable defmt
+defmt = ["dep:defmt", "embassy-hal-internal/defmt", "embassy-sync/defmt", "mec17xx-pac/defmt"]
+
+## Reexport the PAC for the currently enabled chip at `embassy_imxrt::pac` (unstable)
+unstable-pac = []
+
+## Enable the timer for use with `embassy-time` with a 48MHz tick rate.
+time-driver-cct = ["dep:embassy-time-driver", "embassy-time-driver?/tick-hz-48_000_000", "dep:embassy-time-queue-utils"]
+
+# Features starting with `_` are for internal use only. They're not intended
+# to be enabled by other crates, and are not covered by semver guarantees.
+
+
+#! ### Chip selection features
+## CEC1712H_B2_SX
+cec1712h_b2_sx = ["mec17xx-pac/cec1712h_b2_sx"]
+
+## CEC1712H_N2_SX
+cec1712h_n2_sx = ["mec17xx-pac/cec1712h_n2_sx"]
+
+## CEC1712H_S2_SX
+cec1712h_s2_sx = ["mec17xx-pac/cec1712h_s2_sx"]
+
+## CEC1734_S0_2HW
+cec1734_s0_2hw = ["mec17xx-pac/cec1734_s0_2hw"]
+
+## CEC1734_S0_2ZW
+cec1734_s0_2zw = ["mec17xx-pac/cec1734_s0_2zw"]
+
+## CEC1736_S0_2HW
+cec1736_s0_2hw = ["mec17xx-pac/cec1736_s0_2hw"]
+
+## CEC1736_S0_2ZW
+cec1736_s0_2zw = ["mec17xx-pac/cec1736_s0_2zw"]
+
+## MEC1721N_B0_LJ
+mec1721n_b0_lj = ["mec17xx-pac/mec1721n_b0_sz"]
+
+## MEC1721N_B0_SZ
+mec1721n_b0_sz = ["mec17xx-pac/mec1721n_b0_sz"]
+
+## MEC1723N_B0_LJ
+mec1723n_b0_lj = ["mec17xx-pac/mec1723n_b0_lj"]
+
+## MEC1723N_B0_SZ
+mec1723n_b0_sz = ["mec17xx-pac/mec1723n_b0_sz"]
+
+## MEC1723N_F0_SZ
+mec1723n_f0_sz = ["mec17xx-pac/mec1723n_f0_sz"]
+
+## MEC1723N_P0_9Y
+mec1723n_p0_9y = ["mec17xx-pac/mec1723n_p0_9y"]
+
+## MEC1724N_B0_LJ
+mec1724n_b0_lj = ["mec17xx-pac/mec1724n_b0_lj"]
+
+## MEC1723N_B0_SZ
+mec1724n_b0_sz = ["mec17xx-pac/mec1724n_b0_sz"]
+
+## MEC1725
+mec1725n_b0_lj = ["mec17xx-pac/mec1725n_b0_lj"]
+
+## MEC1727N_B0_SZ
+mec1727n_b0_sz = ["mec17xx-pac/mec1727n_b0_sz"]
+
+[dependencies]
+embassy-embedded-hal = { version = "0.3.0", path = "../embassy-embedded-hal" }
+embassy-futures = { version = "0.1.1", path = "../embassy-futures" }
+embassy-hal-internal = { version = "0.2.0", path = "../embassy-hal-internal", features = ["cortex-m", "prio-bits-3"] }
+embassy-sync = { version = "0.6.2", path = "../embassy-sync" }
+embassy-time = { version = "0.4.0", path = "../embassy-time" }
+embassy-time-driver = { version = "0.2", path = "../embassy-time-driver", optional = true }
+embassy-time-queue-utils = { version = "0.1", path = "../embassy-time-queue-utils", optional = true }
+
+defmt = { version = "1.0", optional = true }
+log = { version = "0.4.14", optional = true }
+nb = "1.0.0"
+cortex-m-rt = ">=0.7.3,<0.8"
+cortex-m = "0.7.6"
+critical-section = "1.2"
+fixed = "1.28.0"
+
+embedded-hal-02 = { package = "embedded-hal", version = "0.2.6", features = ["unproven"] }
+embedded-hal-1 = { package = "embedded-hal", version = "1.0" }
+embedded-hal-async = { version = "1.0" }
+embedded-hal-nb = { version = "1.0" }
+
+document-features = "0.2.7"
+
+# PAC
+mec17xx-pac = "0.1.1"

--- a/embassy-microchip/Cargo.toml
+++ b/embassy-microchip/Cargo.toml
@@ -96,7 +96,7 @@ mec1727n_b0_sz = ["mec17xx-pac/mec1727n_b0_sz"]
 embassy-embedded-hal = { version = "0.3.0", path = "../embassy-embedded-hal" }
 embassy-futures = { version = "0.1.1", path = "../embassy-futures" }
 embassy-hal-internal = { version = "0.2.0", path = "../embassy-hal-internal", features = ["cortex-m", "prio-bits-3"] }
-embassy-sync = { version = "0.6.2", path = "../embassy-sync" }
+embassy-sync = { version = "0.7.0", path = "../embassy-sync" }
 embassy-time = { version = "0.4.0", path = "../embassy-time" }
 embassy-time-driver = { version = "0.2", path = "../embassy-time-driver", optional = true }
 embassy-time-queue-utils = { version = "0.1", path = "../embassy-time-queue-utils", optional = true }

--- a/embassy-microchip/README.md
+++ b/embassy-microchip/README.md
@@ -1,0 +1,16 @@
+# Embassy Microchip HAL
+
+HALs implement safe, idiomatic Rust APIs to use the hardware capabilities, so
+raw register manipulation is not needed.
+
+The Embassy Microchip HAL targets the Microchip MEC and CEC Family of MCUs. The
+HAL implements both blocking and async APIs for many peripherals. The benefit of
+using the async APIs is that the HAL takes care of waiting for peripherals to
+complete operations in low power mode and handling of interrupts, so that
+applications can focus on business logic.
+
+NOTE: The Embassy HALs can be used both for non-async and async operations. For
+async, you can choose which runtime you want to use.
+
+For a complete list of available peripherals and features, see the
+[embassy-microchip documentation](https://docs.embassy.dev/embassy-microchip).

--- a/embassy-microchip/src/fmt.rs
+++ b/embassy-microchip/src/fmt.rs
@@ -1,0 +1,257 @@
+#![macro_use]
+#![allow(unused)]
+
+use core::fmt::{Debug, Display, LowerHex};
+
+#[collapse_debuginfo(yes)]
+macro_rules! assert {
+    ($($x:tt)*) => {
+        {
+            #[cfg(not(feature = "defmt"))]
+            ::core::assert!($($x)*);
+            #[cfg(feature = "defmt")]
+            ::defmt::assert!($($x)*);
+        }
+    };
+}
+
+#[collapse_debuginfo(yes)]
+macro_rules! assert_eq {
+    ($($x:tt)*) => {
+        {
+            #[cfg(not(feature = "defmt"))]
+            ::core::assert_eq!($($x)*);
+            #[cfg(feature = "defmt")]
+            ::defmt::assert_eq!($($x)*);
+        }
+    };
+}
+
+#[collapse_debuginfo(yes)]
+macro_rules! assert_ne {
+    ($($x:tt)*) => {
+        {
+            #[cfg(not(feature = "defmt"))]
+            ::core::assert_ne!($($x)*);
+            #[cfg(feature = "defmt")]
+            ::defmt::assert_ne!($($x)*);
+        }
+    };
+}
+
+#[collapse_debuginfo(yes)]
+macro_rules! debug_assert {
+    ($($x:tt)*) => {
+        {
+            #[cfg(not(feature = "defmt"))]
+            ::core::debug_assert!($($x)*);
+            #[cfg(feature = "defmt")]
+            ::defmt::debug_assert!($($x)*);
+        }
+    };
+}
+
+#[collapse_debuginfo(yes)]
+macro_rules! debug_assert_eq {
+    ($($x:tt)*) => {
+        {
+            #[cfg(not(feature = "defmt"))]
+            ::core::debug_assert_eq!($($x)*);
+            #[cfg(feature = "defmt")]
+            ::defmt::debug_assert_eq!($($x)*);
+        }
+    };
+}
+
+#[collapse_debuginfo(yes)]
+macro_rules! debug_assert_ne {
+    ($($x:tt)*) => {
+        {
+            #[cfg(not(feature = "defmt"))]
+            ::core::debug_assert_ne!($($x)*);
+            #[cfg(feature = "defmt")]
+            ::defmt::debug_assert_ne!($($x)*);
+        }
+    };
+}
+
+#[collapse_debuginfo(yes)]
+macro_rules! todo {
+    ($($x:tt)*) => {
+        {
+            #[cfg(not(feature = "defmt"))]
+            ::core::todo!($($x)*);
+            #[cfg(feature = "defmt")]
+            ::defmt::todo!($($x)*);
+        }
+    };
+}
+
+#[collapse_debuginfo(yes)]
+macro_rules! unreachable {
+    ($($x:tt)*) => {
+        {
+            #[cfg(not(feature = "defmt"))]
+            ::core::unreachable!($($x)*);
+            #[cfg(feature = "defmt")]
+            ::defmt::unreachable!($($x)*);
+        }
+    };
+}
+
+#[collapse_debuginfo(yes)]
+macro_rules! panic {
+    ($($x:tt)*) => {
+        {
+            #[cfg(not(feature = "defmt"))]
+            ::core::panic!($($x)*);
+            #[cfg(feature = "defmt")]
+            ::defmt::panic!($($x)*);
+        }
+    };
+}
+
+#[collapse_debuginfo(yes)]
+macro_rules! trace {
+    ($s:literal $(, $x:expr)* $(,)?) => {
+        {
+            #[cfg(feature = "defmt")]
+            ::defmt::trace!($s $(, $x)*);
+            #[cfg(not(feature = "defmt"))]
+            let _ = ($( & $x ),*);
+        }
+    };
+}
+
+#[collapse_debuginfo(yes)]
+macro_rules! debug {
+    ($s:literal $(, $x:expr)* $(,)?) => {
+        {
+            #[cfg(feature = "defmt")]
+            ::defmt::debug!($s $(, $x)*);
+            #[cfg(not(feature = "defmt"))]
+            let _ = ($( & $x ),*);
+        }
+    };
+}
+
+#[collapse_debuginfo(yes)]
+macro_rules! info {
+    ($s:literal $(, $x:expr)* $(,)?) => {
+        {
+            #[cfg(feature = "defmt")]
+            ::defmt::info!($s $(, $x)*);
+            #[cfg(not(feature = "defmt"))]
+            let _ = ($( & $x ),*);
+        }
+    };
+}
+
+#[collapse_debuginfo(yes)]
+macro_rules! warn {
+    ($s:literal $(, $x:expr)* $(,)?) => {
+        {
+            #[cfg(feature = "defmt")]
+            ::defmt::warn!($s $(, $x)*);
+            #[cfg(not(feature = "defmt"))]
+            let _ = ($( & $x ),*);
+        }
+    };
+}
+
+#[collapse_debuginfo(yes)]
+macro_rules! error {
+    ($s:literal $(, $x:expr)* $(,)?) => {
+        {
+            #[cfg(feature = "defmt")]
+            ::defmt::error!($s $(, $x)*);
+            #[cfg(not(feature = "defmt"))]
+            let _ = ($( & $x ),*);
+        }
+    };
+}
+
+#[cfg(feature = "defmt")]
+#[collapse_debuginfo(yes)]
+macro_rules! unwrap {
+    ($($x:tt)*) => {
+        ::defmt::unwrap!($($x)*)
+    };
+}
+
+#[cfg(not(feature = "defmt"))]
+#[collapse_debuginfo(yes)]
+macro_rules! unwrap {
+    ($arg:expr) => {
+        match $crate::fmt::Try::into_result($arg) {
+            ::core::result::Result::Ok(t) => t,
+            ::core::result::Result::Err(e) => {
+                ::core::panic!("unwrap of `{}` failed: {:?}", ::core::stringify!($arg), e);
+            }
+        }
+    };
+    ($arg:expr, $($msg:expr),+ $(,)? ) => {
+        match $crate::fmt::Try::into_result($arg) {
+            ::core::result::Result::Ok(t) => t,
+            ::core::result::Result::Err(e) => {
+                ::core::panic!("unwrap of `{}` failed: {}: {:?}", ::core::stringify!($arg), ::core::format_args!($($msg,)*), e);
+            }
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct NoneError;
+
+pub trait Try {
+    type Ok;
+    type Error;
+    fn into_result(self) -> Result<Self::Ok, Self::Error>;
+}
+
+impl<T> Try for Option<T> {
+    type Ok = T;
+    type Error = NoneError;
+
+    #[inline]
+    fn into_result(self) -> Result<T, NoneError> {
+        self.ok_or(NoneError)
+    }
+}
+
+impl<T, E> Try for Result<T, E> {
+    type Ok = T;
+    type Error = E;
+
+    #[inline]
+    fn into_result(self) -> Self {
+        self
+    }
+}
+
+pub(crate) struct Bytes<'a>(pub &'a [u8]);
+
+impl Debug for Bytes<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{:#02x?}", self.0)
+    }
+}
+
+impl Display for Bytes<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{:#02x?}", self.0)
+    }
+}
+
+impl LowerHex for Bytes<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{:#02x?}", self.0)
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for Bytes<'_> {
+    fn format(&self, fmt: defmt::Formatter) {
+        defmt::write!(fmt, "{:02x}", self.0)
+    }
+}

--- a/embassy-microchip/src/gpio.rs
+++ b/embassy-microchip/src/gpio.rs
@@ -165,13 +165,31 @@ impl<'d> Input<'d> {
     /// Wait until the pin is high. If it is already high, return immediately.
     #[inline]
     pub async fn wait_for_high(&mut self) {
-        self.pin.wait_for_high().await;
+        // TODO - wait_for_high() isn't seeing the pin state change
+        //self.pin.wait_for_high().await;
+        loop {
+            // Wait for the pin to be high, then return.
+            if self.pin.is_high() {
+                return;
+            }
+            // If the pin is not high, yield to allow other tasks to run.
+            //embassy_executor::yield_now().await;
+        }
     }
 
     /// Wait until the pin is low. If it is already low, return immediately.
     #[inline]
     pub async fn wait_for_low(&mut self) {
-        self.pin.wait_for_low().await;
+        // TODO - wait_for_high() isn't seeing the pin state change
+        //self.pin.wait_for_low().await;
+        loop {
+            // Wait for the pin to be low, then return.
+            if self.pin.is_low() {
+                return;
+            }
+            // If the pin is not low, yield to allow other tasks to run.
+            //embassy_executor::yield_now().await;
+        }
     }
 
     /// Wait for the pin to undergo a transition from low to high.

--- a/embassy-microchip/src/gpio.rs
+++ b/embassy-microchip/src/gpio.rs
@@ -1,0 +1,1144 @@
+//! GPIO driver.
+
+#![macro_use]
+use core::future::Future;
+use core::pin::Pin as FuturePin;
+use core::task::{Context, Poll};
+
+use cortex_m::interrupt::InterruptNumber;
+
+use embassy_hal_internal::{impl_peripheral, Peri, PeripheralType};
+use embassy_sync::waitqueue::AtomicWaker;
+
+use crate::interrupt::InterruptExt;
+use crate::pac::common::{Reg, R, RW};
+use crate::pac::gpio::regs::{Ctrl1, Ctrl2};
+use crate::{interrupt, pac, peripherals};
+
+// Each interrupt aggregator block holds a maximum of 31 GPIOs. Some combine a
+// considerably smaller number of pins, but we're still allocating 31
+// `AtomicWaker`s for those.
+pub(crate) const PIN_COUNT: usize = 31;
+
+static GIRQ08_WAKERS: [AtomicWaker; PIN_COUNT] = [const { AtomicWaker::new() }; PIN_COUNT];
+static GIRQ09_WAKERS: [AtomicWaker; PIN_COUNT] = [const { AtomicWaker::new() }; PIN_COUNT];
+static GIRQ10_WAKERS: [AtomicWaker; PIN_COUNT] = [const { AtomicWaker::new() }; PIN_COUNT];
+static GIRQ11_WAKERS: [AtomicWaker; PIN_COUNT] = [const { AtomicWaker::new() }; PIN_COUNT];
+static GIRQ12_WAKERS: [AtomicWaker; PIN_COUNT] = [const { AtomicWaker::new() }; PIN_COUNT];
+static GIRQ26_WAKERS: [AtomicWaker; PIN_COUNT] = [const { AtomicWaker::new() }; PIN_COUNT];
+
+/// Represents a digital input or output level.
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Level {
+    /// Logical low.
+    Low,
+
+    /// Logical high.
+    High,
+}
+
+impl From<bool> for Level {
+    fn from(val: bool) -> Self {
+        match val {
+            true => Self::High,
+            false => Self::Low,
+        }
+    }
+}
+
+impl From<Level> for bool {
+    fn from(level: Level) -> bool {
+        match level {
+            Level::High => true,
+            Level::Low => false,
+        }
+    }
+}
+
+/// Represents a pull setting for an input.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum Pull {
+    /// No pull.
+    None,
+
+    /// Internal pull-up resistor.
+    Up,
+
+    /// Internal pull-down resistor.
+    Down,
+
+    /// Repeater mode. Pin is kept at previous voltage level when no
+    /// active driver is present on the pin.
+    Repeater,
+}
+
+impl From<Pull> for crate::pac::Pull {
+    fn from(val: Pull) -> Self {
+        match val {
+            Pull::None => Self::NONE,
+            Pull::Up => Self::UP,
+            Pull::Down => Self::DOWN,
+            Pull::Repeater => Self::REPEATER,
+        }
+    }
+}
+
+/// Drive strenght of an output.
+#[derive(Debug, Eq, PartialEq)]
+pub enum Drive {
+    /// 2mA for PIO-12, 4mA for PIO-24,
+    Weakest,
+
+    /// 4mA for PIO-12, 8mA for PIO-24,
+    Weak,
+
+    /// 8mA for PIO-12, 16mA for PIO-24,
+    Strong,
+
+    /// 12mA for PIO-12, 24mA for PIO-24,
+    Strongest,
+}
+
+impl From<Drive> for crate::pac::Strength {
+    fn from(val: Drive) -> Self {
+        match val {
+            Drive::Weakest => Self::LOWEST,
+            Drive::Weak => Self::LOW,
+            Drive::Strong => Self::MEDIUM,
+            Drive::Strongest => Self::FULL,
+        }
+    }
+}
+
+/// Slow rate of an output.
+#[derive(Debug, Eq, PartialEq)]
+pub enum SlewRate {
+    /// Slow (half-frequency) slew rate.
+    Slow,
+
+    /// Fast slew rate.
+    Fast,
+}
+
+impl From<SlewRate> for crate::pac::SlewCtrl {
+    fn from(val: SlewRate) -> Self {
+        match val {
+            SlewRate::Slow => Self::SLOW,
+            SlewRate::Fast => Self::FAST,
+        }
+    }
+}
+
+/// GPIO input driber.
+pub struct Input<'d> {
+    pin: Flex<'d>,
+}
+
+impl<'d> Input<'d> {
+    /// Create a GPIO input driver for a [Pin] with the provided [Pull] configuration.
+    #[inline]
+    pub fn new(pin: Peri<'d, impl Pin>, pull: Pull) -> Self {
+        let mut pin = Flex::new(pin);
+        pin.set_as_input();
+        pin.set_pull(pull);
+        Self { pin }
+    }
+
+    /// Get wheter the pin input level is high.
+    #[inline]
+    pub fn is_high(&self) -> bool {
+        self.pin.is_high()
+    }
+
+    /// Get whether the pin input level is low.
+    #[inline]
+    pub fn is_low(&self) -> bool {
+        self.pin.is_low()
+    }
+
+    /// Returns the current pin level
+    #[inline]
+    pub fn get_level(&self) -> Level {
+        self.pin.get_level()
+    }
+
+    /// Wait until the pin is high. If it is already high, return immediately.
+    #[inline]
+    pub async fn wait_for_high(&mut self) {
+        self.pin.wait_for_high().await;
+    }
+
+    /// Wait until the pin is low. If it is already low, return immediately.
+    #[inline]
+    pub async fn wait_for_low(&mut self) {
+        self.pin.wait_for_low().await;
+    }
+
+    /// Wait for the pin to undergo a transition from low to high.
+    #[inline]
+    pub async fn wait_for_rising_edge(&mut self) {
+        self.pin.wait_for_rising_edge().await;
+    }
+
+    /// Wait for the pin to undergo a transition from high to low.
+    #[inline]
+    pub async fn wait_for_falling_edge(&mut self) {
+        self.pin.wait_for_falling_edge().await;
+    }
+
+    /// Wait for the pin to undergo any transition, i.e low to high OR high to low.
+    #[inline]
+    pub async fn wait_for_any_edge(&mut self) {
+        self.pin.wait_for_any_edge().await;
+    }
+}
+
+/// Interrupt trigger levels.
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum InterruptTrigger {
+    /// Trigger on pin low.
+    LevelLow,
+
+    /// Trigger on pin high.
+    LevelHigh,
+
+    /// Trigger on high to low transition.
+    EdgeLow,
+
+    /// Trigger on low to high transition.
+    EdgeHigh,
+
+    /// Trigger on any transition.
+    AnyEdge,
+}
+
+pub unsafe fn init() {
+    // GPIO interrupts must go through the Interrupt Aggregator.
+    let blk_en = 1 << (8 + interrupt::GIRQ08.number())
+        | 1 << (8 + interrupt::GIRQ09.number())
+        | 1 << (8 + interrupt::GIRQ10.number())
+        | 1 << (8 + interrupt::GIRQ11.number())
+        | 1 << (8 + interrupt::GIRQ12.number())
+        | 1 << (8 + interrupt::GIRQ26.number());
+    crate::pac::ECIA.blk_en_set().write(|w| w.set_vtor_en_set(blk_en));
+
+    interrupt::GIRQ08.disable();
+    interrupt::GIRQ09.disable();
+    interrupt::GIRQ10.disable();
+    interrupt::GIRQ11.disable();
+    interrupt::GIRQ12.disable();
+    interrupt::GIRQ26.disable();
+
+    interrupt::GIRQ08.set_priority(interrupt::Priority::P7);
+    interrupt::GIRQ09.set_priority(interrupt::Priority::P7);
+    interrupt::GIRQ10.set_priority(interrupt::Priority::P7);
+    interrupt::GIRQ11.set_priority(interrupt::Priority::P7);
+    interrupt::GIRQ12.set_priority(interrupt::Priority::P7);
+    interrupt::GIRQ26.set_priority(interrupt::Priority::P7);
+
+    interrupt::GIRQ08.unpend();
+    interrupt::GIRQ09.unpend();
+    interrupt::GIRQ10.unpend();
+    interrupt::GIRQ11.unpend();
+    interrupt::GIRQ12.unpend();
+    interrupt::GIRQ26.unpend();
+
+    interrupt::GIRQ08.enable();
+    interrupt::GIRQ09.enable();
+    interrupt::GIRQ10.enable();
+    interrupt::GIRQ11.enable();
+    interrupt::GIRQ12.enable();
+    interrupt::GIRQ26.enable();
+}
+
+#[cfg(feature = "rt")]
+#[interrupt]
+fn GIRQ08() {
+    let regs = InterruptRegs {
+        result: crate::pac::ECIA.result8(),
+        clr: crate::pac::ECIA.en_clr8(),
+    };
+    irq_handler(regs, &GIRQ08_WAKERS);
+}
+
+#[cfg(feature = "rt")]
+#[interrupt]
+fn GIRQ09() {
+    let regs = InterruptRegs {
+        result: crate::pac::ECIA.result9(),
+        clr: crate::pac::ECIA.en_clr9(),
+    };
+    irq_handler(regs, &GIRQ09_WAKERS);
+}
+
+#[cfg(feature = "rt")]
+#[interrupt]
+fn GIRQ10() {
+    let regs = InterruptRegs {
+        result: crate::pac::ECIA.result10(),
+        clr: crate::pac::ECIA.en_clr10(),
+    };
+    irq_handler(regs, &GIRQ10_WAKERS);
+}
+
+#[cfg(feature = "rt")]
+#[interrupt]
+fn GIRQ11() {
+    let regs = InterruptRegs {
+        result: crate::pac::ECIA.result11(),
+        clr: crate::pac::ECIA.en_clr11(),
+    };
+    irq_handler(regs, &GIRQ11_WAKERS);
+}
+
+#[cfg(feature = "rt")]
+#[interrupt]
+fn GIRQ12() {
+    let regs = InterruptRegs {
+        result: crate::pac::ECIA.result12(),
+        clr: crate::pac::ECIA.en_clr12(),
+    };
+    irq_handler(regs, &GIRQ12_WAKERS);
+}
+
+#[cfg(feature = "rt")]
+#[interrupt]
+fn GIRQ26() {
+    let regs = InterruptRegs {
+        result: crate::pac::ECIA.result26(),
+        clr: crate::pac::ECIA.en_clr26(),
+    };
+    irq_handler(regs, &GIRQ26_WAKERS);
+}
+
+#[cfg(feature = "rt")]
+#[inline]
+fn irq_handler(regs: InterruptRegs, wakers: &[AtomicWaker; PIN_COUNT]) {
+    let result = regs.result.read();
+
+    for bit in 0..PIN_COUNT {
+        if result & (1 << bit) != 0 {
+            // mask event
+            regs.clr.write_value(1 << bit);
+            wakers[bit].wake();
+        }
+    }
+}
+
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+struct InputFuture<'d> {
+    pin: Peri<'d, AnyPin>,
+}
+
+impl<'d> InputFuture<'d> {
+    fn new(pin: Peri<'d, AnyPin>, trigger: InterruptTrigger) -> Self {
+        pin.enable_interrupts(trigger);
+        Self { pin }
+    }
+}
+
+impl<'d> Unpin for InputFuture<'d> {}
+impl<'d> Future for InputFuture<'d> {
+    type Output = ();
+
+    fn poll(self: FuturePin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let waker = self.pin.waker();
+        waker.register(cx.waker());
+
+        // IRQ handler will mask the interrupt if the event has occurred. If the
+        // bit for $this event is cleared, that means we triggered an interrupt
+        // and an return control to the application.
+        let set = self.pin.regs().set.read();
+
+        if set & (1 << self.pin.irq_bit()) == 0 {
+            Poll::Ready(())
+        } else {
+            // unmask event so other events can be sampled
+            self.pin.regs().set.write_value(1 << self.pin.irq_bit());
+            Poll::Pending
+        }
+    }
+}
+
+impl<'d> Drop for InputFuture<'d> {
+    fn drop(&mut self) {
+        self.pin.disable_interrupts();
+    }
+}
+
+/// GPIO output driver.
+pub struct Output<'d> {
+    pin: Flex<'d>,
+}
+
+impl<'d> Output<'d> {
+    /// Create GPIO output driver for a [Pin] with the provided [Level].
+    #[inline]
+    pub fn new(pin: Peri<'d, impl Pin>, initial_output: Level) -> Self {
+        let mut pin = Flex::new(pin);
+
+        match initial_output {
+            Level::High => pin.set_high(),
+            Level::Low => pin.set_low(),
+        }
+
+        pin.set_as_output();
+
+        Self { pin }
+    }
+
+    /// Set the pin's drive strength.
+    #[inline]
+    pub fn set_drive_strength(&mut self, strength: Drive) {
+        self.pin.set_drive_strength(strength)
+    }
+
+    /// Set the pin's slew rate.
+    #[inline]
+    pub fn set_slew_rate(&mut self, slew_rate: SlewRate) {
+        self.pin.set_slew_rate(slew_rate)
+    }
+
+    /// Set the outpt as high.
+    #[inline]
+    pub fn set_high(&mut self) {
+        self.pin.set_high()
+    }
+
+    /// Set the output as low.
+    #[inline]
+    pub fn set_low(&mut self) {
+        self.pin.set_low()
+    }
+
+    /// Set the output level.
+    #[inline]
+    pub fn set_level(&mut self, level: Level) {
+        self.pin.set_level(level)
+    }
+
+    /// Is the outpt pin set as high?
+    #[inline]
+    pub fn is_set_high(&self) -> bool {
+        self.pin.is_set_high()
+    }
+
+    /// Is the output pin set as low?
+    #[inline]
+    pub fn is_set_low(&self) -> bool {
+        self.pin.is_set_low()
+    }
+
+    /// What level output is set to
+    #[inline]
+    pub fn get_output_level(&self) -> Level {
+        self.pin.get_output_level()
+    }
+
+    /// Toggle pin output
+    #[inline]
+    pub fn toggle(&mut self) {
+        self.pin.toggle()
+    }
+}
+
+/// GPIO output open-drain.
+pub struct OutputOpenDrain<'d> {
+    pin: Flex<'d>,
+}
+
+impl<'d> OutputOpenDrain<'d> {
+    /// Create GPIO output driver for a [Pin] in open drain mode with the
+    /// provided [Level].
+    #[inline]
+    pub fn new(pin: Peri<'d, impl Pin>, initial_output: Level) -> Self {
+        let mut pin = Flex::new(pin);
+
+        pin.set_as_output_open_drain();
+        pin.set_level(initial_output);
+
+        Self { pin }
+    }
+
+    /// Set the pin's pull-up.
+    #[inline]
+    pub fn set_pullup(&mut self, enable: bool) {
+        if enable {
+            self.pin.set_pull(Pull::Up)
+        } else {
+            self.pin.set_pull(Pull::None)
+        }
+    }
+
+    /// Set the pin's drive strength.
+    #[inline]
+    pub fn set_drive_strength(&mut self, strength: Drive) {
+        self.pin.set_drive_strength(strength)
+    }
+
+    /// Set the pin's slew rate.
+    #[inline]
+    pub fn set_slew_rate(&mut self, slew_rate: SlewRate) {
+        self.pin.set_slew_rate(slew_rate)
+    }
+
+    /// Set the output as high.
+    #[inline]
+    pub fn set_high(&mut self) {
+        self.pin.set_high()
+    }
+
+    /// Set the output as low.
+    #[inline]
+    pub fn set_low(&mut self) {
+        self.pin.set_low()
+    }
+
+    /// Set the output level.
+    #[inline]
+    pub fn set_level(&mut self, level: Level) {
+        self.pin.set_level(level)
+    }
+
+    /// Is the output level high?
+    #[inline]
+    pub fn is_set_high(&self) -> bool {
+        !self.is_set_low()
+    }
+
+    /// Is the output level low?
+    #[inline]
+    pub fn is_set_low(&self) -> bool {
+        self.pin.is_set_as_output()
+    }
+
+    /// What level output is set to
+    #[inline]
+    pub fn get_output_level(&self) -> Level {
+        self.is_set_high().into()
+    }
+
+    /// Toggle pin output
+    #[inline]
+    pub fn toggle(&mut self) {
+        self.pin.toggle()
+    }
+
+    /// Get whether the pin input level is high.
+    #[inline]
+    pub fn is_high(&self) -> bool {
+        self.pin.is_high()
+    }
+
+    /// Get whether the pin input level is low.
+    #[inline]
+    pub fn is_low(&self) -> bool {
+        self.pin.is_low()
+    }
+
+    /// Returns current pin level
+    #[inline]
+    pub fn get_level(&self) -> Level {
+        self.is_high().into()
+    }
+
+    /// Wait until the pin is high. If it is already high, return immediately.
+    #[inline]
+    pub async fn wait_for_high(&mut self) {
+        self.pin.wait_for_high().await;
+    }
+
+    /// Wait until the pin is low. If it is already low, return immediately.
+    #[inline]
+    pub async fn wait_for_low(&mut self) {
+        self.pin.wait_for_low().await;
+    }
+
+    /// Wait for the pin to undergo a transition from low to high.
+    #[inline]
+    pub async fn wait_for_rising_edge(&mut self) {
+        self.pin.wait_for_rising_edge().await;
+    }
+
+    /// Wait for the pin to undergo a transition from high to low.
+    #[inline]
+    pub async fn wait_for_falling_edge(&mut self) {
+        self.pin.wait_for_falling_edge().await;
+    }
+
+    /// Wait for the pin to undergo any transition, i.e low to high OR high to
+    /// low.
+    #[inline]
+    pub async fn wait_for_any_edge(&mut self) {
+        self.pin.wait_for_any_edge().await;
+    }
+}
+
+/// GPIO flexible pin.
+///
+/// This pin can be either an input or output pin. The output level register bit
+/// will remain set while not in output mode, so the pin's level will be
+/// 'remembered' when it is not in output mode.
+pub struct Flex<'d> {
+    pin: Peri<'d, AnyPin>,
+}
+
+impl<'d> Flex<'d> {
+    /// Wrap the pin in a `Flex`.
+    ///
+    /// The pin remains disconnected. The initial output level is unspecified,
+    /// but can be changed before the pin is put into output mode.
+    #[inline]
+    pub fn new(pin: Peri<'d, impl Pin>) -> Self {
+        critical_section::with(|_| {
+            pin.regs().ctrl1.modify(|w| {
+                w.set_mux_ctrl(crate::pac::Function::GPIO);
+                w.set_out_sel(crate::pac::Sel::PIN);
+            })
+        });
+
+        let pin = pin.into();
+        pin.disable_interrupts();
+
+        Self { pin }
+    }
+
+    /// Set the pin's pull.
+    #[inline]
+    pub fn set_pull(&mut self, pull: Pull) {
+        critical_section::with(|_| {
+            self.pin.regs().ctrl1.modify(|w| w.set_pu_pd(pull.into()));
+        });
+    }
+
+    /// Set the pin's drive stength
+    #[inline]
+    pub fn set_drive_strength(&mut self, strength: Drive) {
+        critical_section::with(|_| {
+            self.pin.regs().ctrl2.modify(|w| w.set_driv_stren(strength.into()));
+        });
+    }
+
+    /// Set the pin's slew rate.
+    #[inline]
+    pub fn set_slew_rate(&mut self, slew_rate: SlewRate) {
+        critical_section::with(|_| {
+            self.pin.regs().ctrl2.modify(|w| w.set_slew_ctrl(slew_rate.into()));
+        });
+    }
+
+    /// Put the pin into input mode.
+    ///
+    /// The pull setting is left unchanged.
+    #[inline]
+    pub fn set_as_input(&mut self) {
+        critical_section::with(|_| {
+            self.pin.regs().ctrl1.modify(|w| {
+                w.set_dir(crate::pac::Dir::INPUT);
+                w.set_inp_dis(false);
+            })
+        });
+    }
+
+    /// Put the pin into output mode.
+    ///
+    /// The pin level will be whatever was set before (or low by default). If you want it to begin
+    /// at a specific level, call `set_high`/`set_low` on the pin first.
+    #[inline]
+    pub fn set_as_output(&mut self) {
+        critical_section::with(|_| self.pin.regs().ctrl1.modify(|w| w.set_dir(crate::pac::Dir::OUTPUT)));
+    }
+
+    /// Put the pin into output open drain mode.
+    ///
+    /// The pin level will be whatever was set before (or low by
+    /// default). If you want it to begin at a specific level, call
+    /// `set_high`/`set_low` on the pin first.
+    #[inline]
+    pub fn set_as_output_open_drain(&mut self) {
+        critical_section::with(|_| {
+            self.pin.regs().ctrl1.modify(|w| {
+                w.set_dir(crate::pac::Dir::OUTPUT);
+                w.set_out_buff_type(crate::pac::BufferType::OPEN_DRAIN);
+            })
+        });
+    }
+
+    /// Set as output pin.
+    #[inline]
+    fn is_set_as_output(&self) -> bool {
+        self.pin.regs().ctrl1.read().dir() == crate::pac::Dir::OUTPUT
+    }
+
+    /// Get whether the pin input level is high.
+    #[inline]
+    pub fn is_high(&self) -> bool {
+        self.pin.regs().ctrl1.read().inp()
+    }
+
+    /// Get whether the pin input level is low.
+    #[inline]
+    pub fn is_low(&self) -> bool {
+        !self.is_high()
+    }
+
+    /// Returns current pin level
+    #[inline]
+    pub fn get_level(&self) -> Level {
+        self.is_high().into()
+    }
+
+    /// Set the output as high.
+    #[inline]
+    pub fn set_high(&mut self) {
+        critical_section::with(|_| {
+            self.pin.regs().ctrl1.modify(|w| w.set_alt_data(true));
+        });
+    }
+
+    /// Set the output as low.
+    #[inline]
+    pub fn set_low(&mut self) {
+        critical_section::with(|_| {
+            self.pin.regs().ctrl1.modify(|w| w.set_alt_data(false));
+        });
+    }
+
+    /// Set the output level.
+    #[inline]
+    pub fn set_level(&mut self, level: Level) {
+        match level {
+            Level::Low => self.set_low(),
+            Level::High => self.set_high(),
+        }
+    }
+
+    /// Is the output level high?
+    #[inline]
+    pub fn is_set_high(&self) -> bool {
+        self.pin.regs().ctrl1.read().alt_data()
+    }
+
+    /// Is the output level low?
+    #[inline]
+    pub fn is_set_low(&self) -> bool {
+        !self.is_set_high()
+    }
+
+    /// What level output is set to
+    #[inline]
+    pub fn get_output_level(&self) -> Level {
+        self.is_set_high().into()
+    }
+
+    /// Toggle the output pin
+    #[inline]
+    pub fn toggle(&mut self) {
+        critical_section::with(|_| {
+            let val = self.pin.regs().ctrl1.read().alt_data();
+            self.pin.regs().ctrl1.modify(|w| w.set_alt_data(!val));
+        });
+    }
+
+    /// Wait until the pin is high. If it is already high, return immediately.
+    #[inline]
+    pub async fn wait_for_high(&mut self) {
+        InputFuture::new(self.pin.reborrow(), InterruptTrigger::LevelHigh).await;
+    }
+
+    /// Wait until the pin is low. If it is already low, return immediately.
+    #[inline]
+    pub async fn wait_for_low(&mut self) {
+        InputFuture::new(self.pin.reborrow(), InterruptTrigger::LevelLow).await;
+    }
+
+    /// Wait for the pin to undergo a transition from low to high.
+    #[inline]
+    pub async fn wait_for_rising_edge(&mut self) {
+        InputFuture::new(self.pin.reborrow(), InterruptTrigger::EdgeHigh).await;
+    }
+
+    /// Wait for the pin to undergo a transition from high to low.
+    #[inline]
+    pub async fn wait_for_falling_edge(&mut self) {
+        InputFuture::new(self.pin.reborrow(), InterruptTrigger::EdgeLow).await;
+    }
+
+    /// Wait for the pin to undergo any transition, i.e low to high OR high to low.
+    #[inline]
+    pub async fn wait_for_any_edge(&mut self) {
+        InputFuture::new(self.pin.reborrow(), InterruptTrigger::AnyEdge).await;
+    }
+}
+
+impl<'d> Drop for Flex<'d> {
+    #[inline]
+    fn drop(&mut self) {
+        todo!()
+    }
+}
+
+pub(crate) trait SealedPin: Sized {
+    fn _pin(&self) -> u8;
+    fn _port(&self) -> u8;
+    fn regs(&self) -> Registers;
+    fn irq_id(&self) -> usize;
+    fn irq_bit(&self) -> usize;
+
+    fn waker(&self) -> &AtomicWaker {
+        match self.irq_id() {
+            0 => &GIRQ08_WAKERS[self.irq_bit()],
+            1 => &GIRQ09_WAKERS[self.irq_bit()],
+            2 => &GIRQ10_WAKERS[self.irq_bit()],
+            3 => &GIRQ11_WAKERS[self.irq_bit()],
+            4 => &GIRQ12_WAKERS[self.irq_bit()],
+            17 => &GIRQ26_WAKERS[self.irq_bit()],
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct InterruptRegs {
+    result: Reg<u32, R>,
+    clr: Reg<u32, RW>,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct Registers {
+    pub(crate) ctrl1: Reg<Ctrl1, RW>,
+    pub(crate) ctrl2: Reg<Ctrl2, RW>,
+    pub(crate) src: Reg<u32, RW>,
+    pub(crate) set: Reg<u32, RW>,
+    pub(crate) clr: Reg<u32, RW>,
+}
+
+/// Interface for a [Pin] that can be configured by an [Input] or [Output]
+/// driver, or converted to an [AnyPin].
+#[allow(private_bounds)]
+pub trait Pin: PeripheralType + Into<AnyPin> + SealedPin + Sized + 'static {
+    /// Returns the pin number within a port
+    #[inline]
+    fn pin(&self) -> u8 {
+        self._pin()
+    }
+
+    #[inline]
+    fn port(&self) -> u8 {
+        self._port()
+    }
+}
+
+/// Type-erased GPIO pin
+pub struct AnyPin {
+    pin: u8,
+    port: u8,
+    regs: Registers,
+    irq_id: usize,
+    irq_bit: usize,
+}
+
+impl AnyPin {
+    fn enable_interrupts(&self, trigger: InterruptTrigger) {
+        critical_section::with(|_| {
+            self.regs().clr.write_value(1 << self.irq_bit);
+
+            self.regs().ctrl1.modify(|w| match trigger {
+                InterruptTrigger::LevelLow => {
+                    w.set_edge_en(false);
+                    w.set_intr_det(0);
+                }
+                InterruptTrigger::LevelHigh => {
+                    w.set_edge_en(false);
+                    w.set_intr_det(1);
+                }
+                InterruptTrigger::EdgeLow => {
+                    w.set_edge_en(true);
+                    w.set_intr_det(6);
+                }
+                InterruptTrigger::EdgeHigh => {
+                    w.set_edge_en(true);
+                    w.set_intr_det(5);
+                }
+                InterruptTrigger::AnyEdge => {
+                    w.set_edge_en(true);
+                    w.set_intr_det(7);
+                }
+            });
+
+            self.regs().src.write_value(1 << self.irq_bit);
+            self.regs().set.write_value(1 << self.irq_bit);
+        });
+    }
+
+    fn disable_interrupts(&self) {
+        critical_section::with(|_| {
+            self.regs().ctrl1.modify(|w| {
+                w.set_edge_en(false);
+                w.set_intr_det(4);
+            });
+
+            self.regs().clr.write_value(1 << self.irq_bit);
+        });
+    }
+}
+
+impl_peripheral!(AnyPin);
+
+impl Pin for AnyPin {}
+impl SealedPin for AnyPin {
+    #[inline]
+    fn _pin(&self) -> u8 {
+        self.pin
+    }
+
+    #[inline]
+    fn _port(&self) -> u8 {
+        self.port
+    }
+
+    #[inline]
+    fn regs(&self) -> Registers {
+        self.regs
+    }
+
+    #[inline]
+    fn irq_id(&self) -> usize {
+        self.irq_id
+    }
+
+    #[inline]
+    fn irq_bit(&self) -> usize {
+        self.irq_bit
+    }
+}
+
+macro_rules! impl_pin {
+    ($name:ident, $port:expr, $pin:expr, $irq_id:expr, $irq_bit:expr, $src:ident, $set:ident, $result:ident, $clr:ident) => {
+        impl Pin for peripherals::$name {}
+        impl SealedPin for peripherals::$name {
+            #[inline]
+            fn _pin(&self) -> u8 {
+                $pin
+            }
+
+            #[inline]
+            fn _port(&self) -> u8 {
+                $port
+            }
+
+            #[inline]
+            fn irq_id(&self) -> usize {
+                $irq_id
+            }
+
+            #[inline]
+            fn irq_bit(&self) -> usize {
+                $irq_bit
+            }
+
+            #[inline]
+            fn regs(&self) -> Registers {
+                let ptr = pac::GPIO.as_ptr();
+                let ctrl1 =
+                    unsafe { Reg::from_ptr(ptr.byte_add((($port / 10) << 8) + (($port % 10) << 5) + ($pin * 4)) as _) };
+                let ctrl2 = unsafe {
+                    Reg::from_ptr(ptr.byte_add(0x500 + (($port / 10) << 8) + (($port % 10) << 5) + ($pin * 4)) as _)
+                };
+
+                Registers {
+                    ctrl1,
+                    ctrl2,
+                    src: crate::pac::ECIA.$src(),
+                    set: crate::pac::ECIA.$set(),
+                    clr: crate::pac::ECIA.$clr(),
+                }
+            }
+        }
+
+        impl From<peripherals::$name> for AnyPin {
+            fn from(val: peripherals::$name) -> Self {
+                Self {
+                    pin: val._pin(),
+                    port: val._port(),
+                    regs: val.regs(),
+                    irq_bit: val.irq_bit(),
+                    irq_id: val.irq_id(),
+                }
+            }
+        }
+    };
+}
+
+impl_pin!(GPIO0, 0, 0, 3, 0, src11, en_set11, result11, en_clr11);
+impl_pin!(GPIO1, 0, 1, 3, 1, src11, en_set11, result11, en_clr11);
+impl_pin!(GPIO2, 0, 2, 3, 2, src11, en_set11, result11, en_clr11);
+impl_pin!(GPIO3, 0, 3, 3, 3, src11, en_set11, result11, en_clr11);
+impl_pin!(GPIO4, 0, 4, 3, 4, src11, en_set11, result11, en_clr11);
+impl_pin!(GPIO5, 0, 5, 3, 5, src11, en_set11, result11, en_clr11);
+impl_pin!(GPIO6, 0, 6, 3, 6, src11, en_set11, result11, en_clr11);
+impl_pin!(GPIO7, 0, 7, 3, 7, src11, en_set11, result11, en_clr11);
+
+impl_pin!(GPIO10, 1, 0, 3, 8, src11, en_set11, result11, en_clr11);
+impl_pin!(GPIO11, 1, 1, 3, 9, src11, en_set11, result11, en_clr11);
+impl_pin!(GPIO12, 1, 2, 3, 10, src11, en_set11, result11, en_clr11);
+impl_pin!(GPIO13, 1, 3, 3, 11, src11, en_set11, result11, en_clr11);
+impl_pin!(GPIO14, 1, 4, 3, 12, src11, en_set11, result11, en_clr11);
+impl_pin!(GPIO15, 1, 5, 3, 13, src11, en_set11, result11, en_clr11);
+impl_pin!(GPIO16, 1, 6, 3, 14, src11, en_set11, result11, en_clr11);
+impl_pin!(GPIO17, 1, 7, 3, 15, src11, en_set11, result11, en_clr11);
+
+impl_pin!(GPIO20, 2, 0, 3, 16, src11, en_set11, result11, en_clr11);
+impl_pin!(GPIO21, 2, 1, 3, 17, src11, en_set11, result11, en_clr11);
+impl_pin!(GPIO22, 2, 2, 3, 18, src11, en_set11, result11, en_clr11);
+impl_pin!(GPIO23, 2, 3, 3, 19, src11, en_set11, result11, en_clr11);
+impl_pin!(GPIO24, 2, 4, 3, 20, src11, en_set11, result11, en_clr11);
+impl_pin!(GPIO25, 2, 5, 3, 21, src11, en_set11, result11, en_clr11);
+impl_pin!(GPIO26, 2, 6, 3, 22, src11, en_set11, result11, en_clr11);
+impl_pin!(GPIO27, 2, 7, 3, 23, src11, en_set11, result11, en_clr11);
+
+impl_pin!(GPIO30, 3, 0, 3, 24, src11, en_set11, result11, en_clr11);
+impl_pin!(GPIO31, 3, 1, 3, 25, src11, en_set11, result11, en_clr11);
+impl_pin!(GPIO32, 3, 2, 3, 26, src11, en_set11, result11, en_clr11);
+impl_pin!(GPIO33, 3, 3, 3, 27, src11, en_set11, result11, en_clr11);
+impl_pin!(GPIO34, 3, 4, 3, 28, src11, en_set11, result11, en_clr11);
+impl_pin!(GPIO35, 3, 5, 3, 29, src11, en_set11, result11, en_clr11);
+impl_pin!(GPIO36, 3, 6, 3, 30, src11, en_set11, result11, en_clr11);
+
+impl_pin!(GPIO40, 4, 0, 2, 0, src10, en_set10, result10, en_clr10);
+impl_pin!(GPIO41, 4, 1, 2, 1, src10, en_set10, result10, en_clr10);
+impl_pin!(GPIO42, 4, 2, 2, 2, src10, en_set10, result10, en_clr10);
+impl_pin!(GPIO43, 4, 3, 2, 3, src10, en_set10, result10, en_clr10);
+impl_pin!(GPIO44, 4, 4, 2, 4, src10, en_set10, result10, en_clr10);
+impl_pin!(GPIO45, 4, 5, 2, 5, src10, en_set10, result10, en_clr10);
+impl_pin!(GPIO46, 4, 6, 2, 6, src10, en_set10, result10, en_clr10);
+impl_pin!(GPIO47, 4, 7, 2, 7, src10, en_set10, result10, en_clr10);
+
+impl_pin!(GPIO50, 5, 0, 2, 8, src10, en_set10, result10, en_clr10);
+impl_pin!(GPIO51, 5, 1, 2, 9, src10, en_set10, result10, en_clr10);
+impl_pin!(GPIO52, 5, 2, 2, 10, src10, en_set10, result10, en_clr10);
+impl_pin!(GPIO53, 5, 3, 2, 11, src10, en_set10, result10, en_clr10);
+impl_pin!(GPIO54, 5, 4, 2, 12, src10, en_set10, result10, en_clr10);
+impl_pin!(GPIO55, 5, 5, 2, 13, src10, en_set10, result10, en_clr10);
+impl_pin!(GPIO56, 5, 6, 2, 14, src10, en_set10, result10, en_clr10);
+impl_pin!(GPIO57, 5, 7, 2, 15, src10, en_set10, result10, en_clr10);
+
+impl_pin!(GPIO60, 6, 0, 2, 16, src10, en_set10, result10, en_clr10);
+impl_pin!(GPIO61, 6, 1, 2, 17, src10, en_set10, result10, en_clr10);
+impl_pin!(GPIO62, 6, 2, 2, 18, src10, en_set10, result10, en_clr10);
+impl_pin!(GPIO63, 6, 3, 2, 19, src10, en_set10, result10, en_clr10);
+impl_pin!(GPIO64, 6, 4, 2, 20, src10, en_set10, result10, en_clr10);
+impl_pin!(GPIO65, 6, 5, 2, 21, src10, en_set10, result10, en_clr10);
+impl_pin!(GPIO66, 6, 6, 2, 22, src10, en_set10, result10, en_clr10);
+impl_pin!(GPIO67, 6, 7, 2, 23, src10, en_set10, result10, en_clr10);
+
+impl_pin!(GPIO70, 7, 0, 2, 24, src10, en_set10, result10, en_clr10);
+impl_pin!(GPIO71, 7, 1, 2, 25, src10, en_set10, result10, en_clr10);
+impl_pin!(GPIO72, 7, 2, 2, 26, src10, en_set10, result10, en_clr10);
+impl_pin!(GPIO73, 7, 3, 2, 27, src10, en_set10, result10, en_clr10);
+impl_pin!(GPIO74, 7, 4, 2, 28, src10, en_set10, result10, en_clr10);
+impl_pin!(GPIO75, 7, 5, 2, 29, src10, en_set10, result10, en_clr10);
+impl_pin!(GPIO76, 7, 6, 2, 30, src10, en_set10, result10, en_clr10);
+
+impl_pin!(GPIO100, 10, 0, 1, 0, src9, en_set9, result9, en_clr9);
+impl_pin!(GPIO101, 10, 1, 1, 1, src9, en_set9, result9, en_clr9);
+impl_pin!(GPIO102, 10, 2, 1, 2, src9, en_set9, result9, en_clr9);
+impl_pin!(GPIO103, 10, 3, 1, 3, src9, en_set9, result9, en_clr9);
+impl_pin!(GPIO104, 10, 4, 1, 4, src9, en_set9, result9, en_clr9);
+impl_pin!(GPIO105, 10, 5, 1, 5, src9, en_set9, result9, en_clr9);
+impl_pin!(GPIO106, 10, 6, 1, 6, src9, en_set9, result9, en_clr9);
+impl_pin!(GPIO107, 10, 7, 1, 7, src9, en_set9, result9, en_clr9);
+
+impl_pin!(GPIO112, 11, 2, 1, 10, src9, en_set9, result9, en_clr9);
+impl_pin!(GPIO113, 11, 3, 1, 11, src9, en_set9, result9, en_clr9);
+impl_pin!(GPIO114, 11, 4, 1, 12, src9, en_set9, result9, en_clr9);
+impl_pin!(GPIO115, 11, 5, 1, 13, src9, en_set9, result9, en_clr9);
+impl_pin!(GPIO116, 11, 6, 1, 14, src9, en_set9, result9, en_clr9);
+impl_pin!(GPIO117, 11, 7, 1, 15, src9, en_set9, result9, en_clr9);
+
+impl_pin!(GPIO120, 12, 0, 1, 16, src9, en_set9, result9, en_clr9);
+impl_pin!(GPIO121, 12, 1, 1, 17, src9, en_set9, result9, en_clr9);
+impl_pin!(GPIO122, 12, 2, 1, 18, src9, en_set9, result9, en_clr9);
+impl_pin!(GPIO123, 12, 3, 1, 19, src9, en_set9, result9, en_clr9);
+impl_pin!(GPIO124, 12, 4, 1, 20, src9, en_set9, result9, en_clr9);
+impl_pin!(GPIO125, 12, 5, 1, 21, src9, en_set9, result9, en_clr9);
+impl_pin!(GPIO126, 12, 6, 1, 22, src9, en_set9, result9, en_clr9);
+impl_pin!(GPIO127, 12, 7, 1, 23, src9, en_set9, result9, en_clr9);
+
+impl_pin!(GPIO130, 13, 0, 1, 24, src9, en_set9, result9, en_clr9);
+impl_pin!(GPIO131, 13, 1, 1, 25, src9, en_set9, result9, en_clr9);
+impl_pin!(GPIO132, 13, 2, 1, 26, src9, en_set9, result9, en_clr9);
+impl_pin!(GPIO133, 13, 3, 1, 27, src9, en_set9, result9, en_clr9);
+impl_pin!(GPIO134, 13, 4, 1, 28, src9, en_set9, result9, en_clr9);
+impl_pin!(GPIO135, 13, 5, 1, 29, src9, en_set9, result9, en_clr9);
+
+impl_pin!(GPIO140, 14, 0, 0, 0, src8, en_set8, result8, en_clr8);
+impl_pin!(GPIO141, 14, 1, 0, 1, src8, en_set8, result8, en_clr8);
+impl_pin!(GPIO142, 14, 2, 0, 2, src8, en_set8, result8, en_clr8);
+impl_pin!(GPIO143, 14, 3, 0, 3, src8, en_set8, result8, en_clr8);
+impl_pin!(GPIO144, 14, 4, 0, 4, src8, en_set8, result8, en_clr8);
+impl_pin!(GPIO145, 14, 5, 0, 5, src8, en_set8, result8, en_clr8);
+impl_pin!(GPIO146, 14, 6, 0, 6, src8, en_set8, result8, en_clr8);
+impl_pin!(GPIO147, 14, 7, 0, 7, src8, en_set8, result8, en_clr8);
+
+impl_pin!(GPIO150, 15, 0, 0, 8, src8, en_set8, result8, en_clr8);
+impl_pin!(GPIO151, 15, 1, 0, 9, src8, en_set8, result8, en_clr8);
+impl_pin!(GPIO152, 15, 2, 0, 10, src8, en_set8, result8, en_clr8);
+impl_pin!(GPIO153, 15, 3, 0, 11, src8, en_set8, result8, en_clr8);
+impl_pin!(GPIO154, 15, 4, 0, 12, src8, en_set8, result8, en_clr8);
+impl_pin!(GPIO155, 15, 5, 0, 13, src8, en_set8, result8, en_clr8);
+impl_pin!(GPIO156, 15, 6, 0, 14, src8, en_set8, result8, en_clr8);
+impl_pin!(GPIO157, 15, 7, 0, 15, src8, en_set8, result8, en_clr8);
+
+impl_pin!(GPIO160, 16, 0, 0, 16, src8, en_set8, result8, en_clr8);
+impl_pin!(GPIO161, 16, 1, 0, 17, src8, en_set8, result8, en_clr8);
+impl_pin!(GPIO162, 16, 2, 0, 18, src8, en_set8, result8, en_clr8);
+impl_pin!(GPIO165, 16, 5, 0, 21, src8, en_set8, result8, en_clr8);
+impl_pin!(GPIO166, 16, 6, 0, 22, src8, en_set8, result8, en_clr8);
+
+impl_pin!(GPIO170, 17, 0, 0, 24, src8, en_set8, result8, en_clr8);
+impl_pin!(GPIO171, 17, 1, 0, 25, src8, en_set8, result8, en_clr8);
+impl_pin!(GPIO172, 17, 2, 0, 26, src8, en_set8, result8, en_clr8);
+impl_pin!(GPIO173, 17, 3, 0, 27, src8, en_set8, result8, en_clr8);
+impl_pin!(GPIO174, 17, 4, 0, 28, src8, en_set8, result8, en_clr8);
+impl_pin!(GPIO175, 17, 5, 0, 29, src8, en_set8, result8, en_clr8);
+
+impl_pin!(GPIO200, 20, 0, 4, 0, src12, en_set12, result12, en_clr12);
+impl_pin!(GPIO201, 20, 1, 4, 1, src12, en_set12, result12, en_clr12);
+impl_pin!(GPIO202, 20, 2, 4, 2, src12, en_set12, result12, en_clr12);
+impl_pin!(GPIO203, 20, 3, 4, 3, src12, en_set12, result12, en_clr12);
+impl_pin!(GPIO204, 20, 4, 4, 4, src12, en_set12, result12, en_clr12);
+impl_pin!(GPIO205, 20, 5, 4, 5, src12, en_set12, result12, en_clr12);
+impl_pin!(GPIO206, 20, 6, 4, 6, src12, en_set12, result12, en_clr12);
+impl_pin!(GPIO207, 20, 7, 4, 7, src12, en_set12, result12, en_clr12);
+
+impl_pin!(GPIO210, 21, 0, 4, 8, src12, en_set12, result12, en_clr12);
+impl_pin!(GPIO211, 21, 1, 4, 9, src12, en_set12, result12, en_clr12);
+impl_pin!(GPIO212, 21, 2, 4, 10, src12, en_set12, result12, en_clr12);
+impl_pin!(GPIO213, 21, 3, 4, 11, src12, en_set12, result12, en_clr12);
+impl_pin!(GPIO214, 21, 4, 4, 12, src12, en_set12, result12, en_clr12);
+impl_pin!(GPIO215, 21, 5, 4, 13, src12, en_set12, result12, en_clr12);
+impl_pin!(GPIO216, 21, 6, 4, 14, src12, en_set12, result12, en_clr12);
+impl_pin!(GPIO217, 21, 7, 4, 15, src12, en_set12, result12, en_clr12);
+
+impl_pin!(GPIO221, 22, 1, 4, 17, src12, en_set12, result12, en_clr12);
+impl_pin!(GPIO222, 22, 2, 4, 18, src12, en_set12, result12, en_clr12);
+impl_pin!(GPIO223, 22, 3, 4, 19, src12, en_set12, result12, en_clr12);
+impl_pin!(GPIO224, 22, 4, 4, 20, src12, en_set12, result12, en_clr12);
+impl_pin!(GPIO225, 22, 5, 4, 21, src12, en_set12, result12, en_clr12);
+impl_pin!(GPIO226, 22, 6, 4, 22, src12, en_set12, result12, en_clr12);
+impl_pin!(GPIO227, 22, 7, 4, 23, src12, en_set12, result12, en_clr12);
+
+impl_pin!(GPIO240, 24, 0, 17, 0, src26, en_set26, result26, en_clr26);
+impl_pin!(GPIO241, 24, 1, 17, 1, src26, en_set26, result26, en_clr26);
+impl_pin!(GPIO242, 24, 2, 17, 2, src26, en_set26, result26, en_clr26);
+impl_pin!(GPIO243, 24, 3, 17, 3, src26, en_set26, result26, en_clr26);
+impl_pin!(GPIO244, 24, 4, 17, 4, src26, en_set26, result26, en_clr26);
+impl_pin!(GPIO245, 24, 5, 17, 5, src26, en_set26, result26, en_clr26);
+impl_pin!(GPIO246, 24, 6, 17, 6, src26, en_set26, result26, en_clr26);
+impl_pin!(GPIO247, 24, 7, 17, 7, src26, en_set26, result26, en_clr26);
+
+impl_pin!(GPIO254, 25, 4, 17, 12, src26, en_set26, result26, en_clr26);
+impl_pin!(GPIO255, 25, 5, 17, 13, src26, en_set26, result26, en_clr26);

--- a/embassy-microchip/src/gpio.rs
+++ b/embassy-microchip/src/gpio.rs
@@ -6,7 +6,6 @@ use core::pin::Pin as FuturePin;
 use core::task::{Context, Poll};
 
 use cortex_m::interrupt::InterruptNumber;
-
 use embassy_hal_internal::{impl_peripheral, Peri, PeripheralType};
 use embassy_sync::waitqueue::AtomicWaker;
 
@@ -1130,6 +1129,9 @@ impl_pin!(GPIO224, 22, 4, 4, 20, src12, en_set12, result12, en_clr12);
 impl_pin!(GPIO225, 22, 5, 4, 21, src12, en_set12, result12, en_clr12);
 impl_pin!(GPIO226, 22, 6, 4, 22, src12, en_set12, result12, en_clr12);
 impl_pin!(GPIO227, 22, 7, 4, 23, src12, en_set12, result12, en_clr12);
+
+impl_pin!(GPIO230, 23, 0, 4, 23, src11, en_set11, result11, en_clr11);
+impl_pin!(GPIO231, 23, 0, 4, 23, src11, en_set11, result11, en_clr11);
 
 impl_pin!(GPIO240, 24, 0, 17, 0, src26, en_set26, result26, en_clr26);
 impl_pin!(GPIO241, 24, 1, 17, 1, src26, en_set26, result26, en_clr26);

--- a/embassy-microchip/src/i2c.rs
+++ b/embassy-microchip/src/i2c.rs
@@ -1,0 +1,1164 @@
+//! I2C driver.
+
+use core::future;
+use core::marker::PhantomData;
+use core::task::Poll;
+
+use embassy_hal_internal::{Peri, PeripheralType};
+use embassy_sync::waitqueue::AtomicWaker;
+use pac::smb0;
+
+use crate::gpio::{AnyPin, SealedPin};
+use crate::interrupt::typelevel::{Binding, Interrupt};
+use crate::{interrupt, pac, peripherals};
+
+/// I2c error abort reason
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum AbortReason {
+    /// A bus operation was not acknowledged.
+    NoAcknowledge,
+
+    /// Lost arbitration
+    ArbitrationLoss,
+
+    /// Other reason
+    Other,
+}
+
+/// I2C error bus timeout reason
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum BusTimeoutReason {
+    /// Clock high, data high timeout
+    ClockHighDataHigh,
+
+    /// Clock high, data low timeout
+    ClockHighDataLow,
+
+    /// Slave cumulative timeout
+    SlaveCumulativeTimeout,
+
+    /// Master cumulative timeout
+    MasterCumulativeTimeout,
+
+    /// Device timeout
+    DeviceTimeout,
+}
+
+/// I2C error
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Error {
+    /// I2C abort with error
+    Abort(AbortReason),
+
+    /// Bus timeout
+    BusTimeout(BusTimeoutReason),
+
+    /// User passed in a read buffer with 0 length
+    InvalidReadBufferLength,
+
+    /// User passed in a write buffer with 0 length
+    InvalidWriteBufferLength,
+
+    /// Target I2C address is out of range
+    AddressOutOfRange(u8),
+
+    /// Target I2C address is reserved
+    AddressReserved(u8),
+}
+
+/// I2C config error
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ConfigError {
+    /// Max I2C frequency is 1MHz
+    FrequencyTooHigh,
+
+    /// The baud rate clock is too slow to support the requested
+    /// frequency
+    ClockTooSlow,
+
+    /// The baud rate clock is too fast to support the requested
+    /// frequency
+    ClockTooFast,
+}
+
+/// I2C bus speeds
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum BusSpeed {
+    /// 100kHz
+    Standard,
+
+    /// 400kHz,
+    Fast,
+
+    /// 1MHz,
+    FastPlus,
+}
+
+/// I2C config
+#[non_exhaustive]
+#[derive(Copy, Clone)]
+pub struct Config {
+    /// Bus speed.
+    pub speed: BusSpeed,
+
+    /// Own address 1 in 7-bit format.
+    ///
+    /// The internal master should not attempt transactions to a slave
+    /// with the same address as `addr1`. This represents an illegal
+    /// operation.
+    ///
+    /// Passing `None` results in the value 0 being written to the Own
+    /// Address register and General Call Match to be disabled.
+    pub addr1: Option<u8>,
+
+    /// Own address 2 in 7-bit format.
+    ///
+    /// The internal master should not attempt transactions to a slave
+    /// with the same address as `addr2`. This represents an illegal
+    /// operation.
+    ///
+    /// Passing `None` results in the value 0 being written to the Own
+    /// Address register and General Call Match to be disabled.
+    pub addr2: Option<u8>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            speed: BusSpeed::Standard,
+            addr1: Some(0x7f),
+            addr2: Some(0x7f),
+        }
+    }
+}
+
+/// I2C driver.
+pub struct I2c<'d, T: Instance, M: Mode> {
+    _peri: Peri<'d, T>,
+    _sda: Peri<'d, AnyPin>,
+    _scl: Peri<'d, AnyPin>,
+    config: Config,
+    port: u8,
+    phantom: PhantomData<M>,
+}
+
+impl<'d, T: Instance> I2c<'d, T, Blocking> {
+    /// Create a new driver instance in blocking mode.
+    pub fn new_blocking<SCL: SclPin, SDA: SdaPin>(
+        _peri: Peri<'d, T>,
+        _scl: Peri<'d, SCL>,
+        _sda: Peri<'d, SDA>,
+        config: Config,
+    ) -> Self
+    where
+        (T, SCL, SDA): ValidI2cConfig,
+    {
+        _scl.setup();
+        _sda.setup();
+
+        let port = <(T, SCL, SDA) as SealedValidI2cConfig>::port();
+        Self::new_inner(_peri, _scl.into(), _sda.into(), config, port)
+    }
+}
+
+impl<'d, T: Instance> I2c<'d, T, Async> {
+    /// Create a new driver instance in async mode.
+    pub fn new_async<SCL: SclPin, SDA: SdaPin>(
+        _peri: Peri<'d, T>,
+        _scl: Peri<'d, SCL>,
+        _sda: Peri<'d, SDA>,
+        _irq: impl Binding<T::Interrupt, InterruptHandler<T>>,
+        config: Config,
+    ) -> Self
+    where
+        (T, SCL, SDA): ValidI2cConfig,
+    {
+        // mask all interrupts
+        pac::ECIA.src13().write_value(1 << T::irq_bit());
+        pac::ECIA.en_clr13().write_value(1 << T::irq_bit());
+
+        _scl.setup();
+        _sda.setup();
+
+        let port = <(T, SCL, SDA) as SealedValidI2cConfig>::port();
+        let i2c = Self::new_inner(_peri, _scl.into(), _sda.into(), config, port);
+
+        // unmask interrupt
+        pac::ECIA.en_set13().write_value(1 << T::irq_bit());
+
+        T::Interrupt::unpend();
+        unsafe { T::Interrupt::enable() };
+
+        i2c
+    }
+
+    /// Calls `f` to check if we are ready or not.
+    /// If not, `g` is called once(to eg enable the required interrupts).
+    /// The waker will always be registered prior to calling `f`.
+    async fn wait_on<F, U, G>(&mut self, mut f: F, mut g: G) -> U
+    where
+        F: FnMut(&mut Self) -> Poll<U>,
+        G: FnMut(&mut Self),
+    {
+        future::poll_fn(|cx| {
+            // Register prior to checking the condition
+            T::waker().register(cx.waker());
+            let r = f(self);
+
+            if r.is_pending() {
+                g(self);
+            }
+            r
+        })
+        .await
+    }
+
+    async fn wait_for_bus_free_async(&mut self) -> Result<(), Error> {
+        self.wait_on(
+            |_| {
+                let compl = T::regs().compl().read();
+                let sts = T::regs().rsts().read();
+
+                if sts.nbb() {
+                    T::regs().compl().write(|w| w.set_idle(true));
+                    Poll::Ready(Ok(()))
+                } else if compl.lab() {
+                    T::regs().compl().write(|w| w.set_lab(true));
+                    Poll::Ready(Err(Error::Abort(AbortReason::ArbitrationLoss)))
+                } else if compl.ber() && compl.dto() {
+                    T::regs().compl().write(|w| w.set_dto(true));
+                    Poll::Ready(Err(Error::BusTimeout(BusTimeoutReason::DeviceTimeout)))
+                } else if compl.ber() && compl.mcto() {
+                    T::regs().compl().write(|w| w.set_mcto(true));
+                    Poll::Ready(Err(Error::BusTimeout(BusTimeoutReason::MasterCumulativeTimeout)))
+                } else if compl.ber() && compl.chdl() {
+                    T::regs().compl().write(|w| w.set_chdl(true));
+                    Poll::Ready(Err(Error::BusTimeout(BusTimeoutReason::ClockHighDataLow)))
+                } else if compl.ber() && compl.chdh() {
+                    T::regs().compl().write(|w| w.set_chdh(true));
+                    Poll::Ready(Err(Error::BusTimeout(BusTimeoutReason::ClockHighDataHigh)))
+                } else if compl.ber() {
+                    T::regs().compl().write(|w| w.set_ber(true));
+                    Poll::Ready(Err(Error::Abort(AbortReason::Other)))
+                } else {
+                    Poll::Pending
+                }
+            },
+            |_| {
+                T::regs().cfg().modify(|w| w.set_enidi(true));
+            },
+        )
+        .await
+    }
+
+    async fn wait_for_completion_async(&mut self) -> Result<(), Error> {
+        self.wait_on(
+            |_| {
+                let compl = T::regs().compl().read();
+                let sts = T::regs().rsts().read();
+
+                if sts.pin() {
+                    Poll::Pending
+                } else if !sts.lrb_ad0() {
+                    Poll::Ready(Ok(()))
+                } else if compl.lab() {
+                    T::regs().compl().write(|w| w.set_lab(true));
+                    Poll::Ready(Err(Error::Abort(AbortReason::ArbitrationLoss)))
+                } else if compl.ber() && compl.dto() {
+                    T::regs().compl().write(|w| w.set_dto(true));
+                    Poll::Ready(Err(Error::BusTimeout(BusTimeoutReason::DeviceTimeout)))
+                } else if compl.ber() && compl.mcto() {
+                    T::regs().compl().write(|w| w.set_mcto(true));
+                    Poll::Ready(Err(Error::BusTimeout(BusTimeoutReason::MasterCumulativeTimeout)))
+                } else if compl.ber() && compl.chdl() {
+                    T::regs().compl().write(|w| w.set_chdl(true));
+                    Poll::Ready(Err(Error::BusTimeout(BusTimeoutReason::ClockHighDataLow)))
+                } else if compl.ber() && compl.chdh() {
+                    T::regs().compl().write(|w| w.set_chdh(true));
+                    Poll::Ready(Err(Error::BusTimeout(BusTimeoutReason::ClockHighDataHigh)))
+                } else if compl.ber() {
+                    T::regs().compl().write(|w| w.set_ber(true));
+                    Poll::Ready(Err(Error::Abort(AbortReason::Other)))
+                } else {
+                    Poll::Pending
+                }
+            },
+            |_| {
+                T::regs().cfg().modify(|w| {
+                    w.set_enidi(true);
+                    w.set_enmi(true);
+                    w.set_ensi(true);
+                });
+            },
+        )
+        .await
+    }
+
+    async fn start_async(&mut self, address: u8, rw: bool, repeated: bool) -> Result<(), Error> {
+        if address >= 0x80 {
+            return Err(Error::AddressOutOfRange(address));
+        }
+
+        let r = T::regs();
+        let own_addr = r.own_addr().read();
+        let (addr1, addr2) = (own_addr.addr1(), own_addr.addr2());
+
+        if address == addr1 || address == addr2 {
+            return Err(Error::AddressReserved(address));
+        }
+
+        if repeated {
+            T::regs().wctrl().write(|w| {
+                w.set_eso(true);
+                w.set_sta(true);
+                w.set_ack(true);
+            });
+            T::regs().i2cdata().write_value(address << 1 | u8::from(rw));
+        } else {
+            if rw {
+                T::regs().i2cdata().write_value(address << 1 | 1);
+                self.wait_for_bus_free_async().await?;
+            } else {
+                self.wait_for_bus_free_async().await?;
+                T::regs().i2cdata().write_value(address << 1 | 0);
+            }
+
+            T::regs().wctrl().write(|w| {
+                w.set_pin(true);
+                w.set_eso(true);
+                w.set_sta(true);
+                w.set_ack(true);
+            });
+
+            self.wait_for_completion_async().await?;
+        }
+
+        Ok(())
+    }
+
+    async fn read_byte_async(&mut self) -> Result<u8, Error> {
+        self.wait_for_completion_async().await?;
+        let byte = T::regs().i2cdata().read();
+        Ok(byte)
+    }
+
+    async fn write_byte_async(&mut self, byte: u8) -> Result<(), Error> {
+        self.wait_for_completion_async().await?;
+        T::regs().i2cdata().write_value(byte);
+        Ok(())
+    }
+
+    async fn read_async_internal(
+        &mut self,
+        address: u8,
+        read: &mut [u8],
+        repeated: bool,
+        send_stop: bool,
+    ) -> Result<(), Error> {
+        if read.is_empty() {
+            return Err(Error::InvalidReadBufferLength);
+        }
+
+        self.start_async(address, true, repeated).await?;
+
+        // First byte in the FIFO is the slave address. Ignore it.
+        let _ = self.read_byte_async().await?;
+
+        let last = read.len() - 1;
+        for (i, byte) in read.iter_mut().enumerate() {
+            if i == last {
+                T::regs().wctrl().write(|w| {
+                    w.set_eso(true);
+                });
+            }
+
+            let b = self.read_byte_async().await?;
+            *byte = b;
+        }
+
+        if send_stop {
+            Self::stop();
+        }
+
+        Ok(())
+    }
+
+    async fn write_async_internal(&mut self, address: u8, write: &[u8], send_stop: bool) -> Result<(), Error> {
+        if write.is_empty() {
+            return Err(Error::InvalidWriteBufferLength);
+        }
+
+        self.start_async(address, false, false).await?;
+
+        for byte in write.iter() {
+            self.write_byte_async(*byte).await?;
+        }
+
+        if send_stop {
+            Self::stop();
+        }
+
+        Ok(())
+    }
+
+    /// Read from address into read asynchronously.
+    pub async fn read_async(&mut self, address: u8, read: &mut [u8]) -> Result<(), Error> {
+        self.read_async_internal(address, read, false, true).await
+    }
+
+    /// Write to address from write asynchronously.
+    pub async fn write_async(&mut self, address: u8, write: &[u8]) -> Result<(), Error> {
+        self.write_async_internal(address, write, true).await
+    }
+
+    /// Write to address from write and read from address into read asynchronously.
+    pub async fn write_read_async(&mut self, address: u8, write: &[u8], read: &mut [u8]) -> Result<(), Error> {
+        self.write_async_internal(address, write, false).await?;
+        self.read_async_internal(address, read, true, true).await
+    }
+}
+
+/// Interrupt handler.
+pub struct InterruptHandler<T: Instance> {
+    _phantom: PhantomData<T>,
+}
+
+impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandler<T> {
+    unsafe fn on_interrupt() {
+        pac::ECIA.src13().write_value(1 << T::irq_bit());
+
+        T::regs().cfg().modify(|w| {
+            w.set_enmi(false);
+            w.set_enidi(false);
+            w.set_en_aas(false);
+        });
+
+        T::waker().wake();
+    }
+}
+
+impl<'d, T: Instance + 'd, M: Mode> I2c<'d, T, M> {
+    fn new_inner(_peri: Peri<'d, T>, _scl: Peri<'d, AnyPin>, _sda: Peri<'d, AnyPin>, config: Config, port: u8) -> Self {
+        let mut i2c = Self {
+            _peri,
+            _scl,
+            _sda,
+            config,
+            port,
+            phantom: PhantomData,
+        };
+        i2c.reset_reconfigure();
+        i2c
+    }
+
+    fn reset_reconfigure(&mut self) {
+        let r = T::regs();
+
+        let addr1 = self.config.addr1.unwrap_or(0);
+        let addr2 = self.config.addr2.unwrap_or(0);
+
+        critical_section::with(|_| {
+            // Reset the controller first.
+            r.cfg().write(|w| w.set_rst(true));
+            // Reset must remain set for at least 1 period of the 16MHz
+            // clock. Fastest CPU clock is 48MHz. If we delay for a
+            // minimum of 10 cycles of the CPU clock, we're good.
+            r.cfg().write(|w| w.set_rst(false));
+
+            r.cfg().write(|w| {
+                w.set_flush_sxbuf(true);
+                w.set_flush_srbuf(true);
+                w.set_flush_mxbuf(true);
+                w.set_flush_mrbuf(true);
+            });
+
+            r.wctrl().write(|w| w.set_pin(true));
+            r.own_addr().write(|w| {
+                w.set_addr1(addr1);
+                w.set_addr2(addr2);
+            });
+
+            r.cfg().write(|w| {
+                if addr1 == 0 || addr2 == 0 {
+                    w.set_gc_dis(false);
+                }
+                w.set_port_sel(self.port);
+                w.set_fen(true);
+            });
+
+            match self.config.speed {
+                BusSpeed::Standard => {
+                    r.busclk().write(|w| {
+                        w.set_low_per(0x4f);
+                        w.set_high_per(0x4f);
+                    });
+                    r.datatm().write(|w| {
+                        w.set_data_hold(0x06);
+                        w.set_restart_setup(0x50);
+                        w.set_stop_setup(0x4d);
+                        w.set_first_start_hold(0x0c);
+                    });
+
+                    r.rshtm().write(|w| w.set_rshtm(0x4d));
+                    r.idlsc().write(|w| {
+                        w.set_fair_bus_idl_min(0x01ed);
+                        w.set_fair_idl_dly(0x01fc);
+                    });
+                    r.tmoutsc().write(|w| {
+                        w.set_clk_high_tim_out(0xc7);
+                        w.set_slv_cum_tim_out(0xc2);
+                        w.set_mast_cum_tim_out(0x9c);
+                        w.set_bus_idle_min(0x4b);
+                    });
+                }
+                BusSpeed::Fast => {
+                    r.busclk().write(|w| {
+                        w.set_low_per(0x17);
+                        w.set_high_per(0x0f);
+                    });
+                    r.datatm().write(|w| {
+                        w.set_data_hold(0x06);
+                        w.set_restart_setup(0x0a);
+                        w.set_stop_setup(0x0a);
+                        w.set_first_start_hold(0x04);
+                    });
+
+                    r.rshtm().write(|w| w.set_rshtm(0x0a));
+                    r.idlsc().write(|w| {
+                        w.set_fair_bus_idl_min(0x0050);
+                        w.set_fair_idl_dly(0x0100);
+                    });
+                    r.tmoutsc().write(|w| {
+                        w.set_clk_high_tim_out(0xc7);
+                        w.set_slv_cum_tim_out(0xc2);
+                        w.set_mast_cum_tim_out(0x9c);
+                        w.set_bus_idle_min(0x15);
+                    });
+                }
+                BusSpeed::FastPlus => {
+                    r.busclk().write(|w| {
+                        w.set_low_per(0x09);
+                        w.set_high_per(0x05);
+                    });
+                    r.datatm().write(|w| {
+                        w.set_data_hold(0x01);
+                        w.set_restart_setup(0x06);
+                        w.set_stop_setup(0x06);
+                        w.set_first_start_hold(0x04);
+                    });
+
+                    r.rshtm().write(|w| w.set_rshtm(0x06));
+                    r.idlsc().write(|w| {
+                        w.set_fair_bus_idl_min(0x0050);
+                        w.set_fair_idl_dly(0x0100);
+                    });
+                    r.tmoutsc().write(|w| {
+                        w.set_clk_high_tim_out(0xc7);
+                        w.set_slv_cum_tim_out(0xc2);
+                        w.set_mast_cum_tim_out(0x9c);
+                        w.set_bus_idle_min(0x08);
+                    });
+                }
+            }
+
+            r.wctrl().write(|w| {
+                w.set_pin(true);
+                w.set_eso(true);
+                w.set_ack(true);
+            });
+
+            r.cfg().modify(|w| w.set_en(true));
+        });
+
+        while !r.rsts().read().nbb() {}
+
+        // 6. Delay.
+        //
+        // Documentation states: Wait a time equal to the longest i2c
+        // message to synchronize the NBB bit in multi-master systems
+        // only.
+        //
+        // We're assuming that we're not in a multi-master scenario,
+        // therefore skipping the delay.
+    }
+
+    fn wait_for_bus_free() {
+        while !T::regs().rsts().read().nbb() {}
+    }
+
+    fn start(address: u8, rw: bool, repeated: bool) -> Result<(), Error> {
+        if address >= 0x80 {
+            return Err(Error::AddressOutOfRange(address));
+        }
+
+        let r = T::regs();
+        let own_addr = r.own_addr().read();
+        let (addr1, addr2) = (own_addr.addr1(), own_addr.addr2());
+
+        if address == addr1 || address == addr2 {
+            return Err(Error::AddressReserved(address));
+        }
+
+        if repeated {
+            T::regs().wctrl().write(|w| {
+                w.set_eso(true);
+                w.set_sta(true);
+                w.set_ack(true);
+            });
+            T::regs().i2cdata().write_value(address << 1 | u8::from(rw));
+        } else {
+            if rw {
+                T::regs().i2cdata().write_value(address << 1 | 1);
+                Self::wait_for_bus_free();
+            } else {
+                Self::wait_for_bus_free();
+                T::regs().i2cdata().write_value(address << 1 | 0);
+            }
+
+            T::regs().wctrl().write(|w| {
+                w.set_pin(true);
+                w.set_eso(true);
+                w.set_sta(true);
+                w.set_ack(true);
+            });
+        }
+
+        Ok(())
+    }
+
+    fn stop() {
+        T::regs().wctrl().write(|w| {
+            w.set_pin(true);
+            w.set_eso(true);
+            w.set_sto(true);
+            w.set_sta(false);
+            w.set_ack(true);
+        });
+    }
+
+    fn check_status() -> Result<(), Error> {
+        while T::regs().rsts().read().pin() {
+            cortex_m::asm::delay(500_000);
+
+            let status = T::regs().rsts().read();
+            let compl = T::regs().compl().read();
+            defmt::debug!("STATUS: {} COMPL {}", status, compl);
+        }
+
+        let status = T::regs().rsts().read();
+        defmt::debug!("STATUS: {}", status);
+
+        if status.lrb_ad0() {
+            Self::stop();
+            Err(Error::Abort(AbortReason::NoAcknowledge))
+        } else if status.lab() {
+            Err(Error::Abort(AbortReason::ArbitrationLoss))
+        } else if status.ber() {
+            let completion = T::regs().compl().read();
+
+            if completion.dto() {
+                Err(Error::BusTimeout(BusTimeoutReason::DeviceTimeout))
+            } else if completion.mcto() {
+                Err(Error::BusTimeout(BusTimeoutReason::MasterCumulativeTimeout))
+            } else if completion.chdl() {
+                Err(Error::BusTimeout(BusTimeoutReason::ClockHighDataLow))
+            } else if completion.chdh() {
+                Err(Error::BusTimeout(BusTimeoutReason::ClockHighDataHigh))
+            } else {
+                Err(Error::Abort(AbortReason::Other))
+            }
+        } else {
+            Ok(())
+        }
+    }
+
+    fn read_byte(last: bool) -> Result<u8, Error> {
+        if !last {
+            defmt::debug!("R: CHECK STATUS not last");
+            Self::check_status()?;
+        } else {
+            defmt::debug!("R: Update WCTRL for last");
+            T::regs().wctrl().write(|w| {
+                w.set_eso(true);
+            });
+        }
+
+        defmt::debug!("R: Read data register");
+        let byte = T::regs().i2cdata().read();
+
+        if last {
+            defmt::debug!("R: CHECK STATUS for last");
+            Self::check_status()?;
+        }
+
+        Ok(byte)
+    }
+
+    fn write_byte(byte: u8) -> Result<(), Error> {
+        defmt::debug!("W: CHECK STATUS");
+        Self::check_status()?;
+        defmt::debug!("W: write to data register");
+        T::regs().i2cdata().write_value(byte);
+        Ok(())
+    }
+
+    fn read_blocking_internal(
+        &mut self,
+        address: u8,
+        read: &mut [u8],
+        repeated: bool,
+        send_stop: bool,
+    ) -> Result<(), Error> {
+        if read.is_empty() {
+            return Err(Error::InvalidReadBufferLength);
+        }
+
+        defmt::debug!("R: START");
+        Self::start(address, true, repeated)?;
+
+        // First byte in the FIFO is the slave address. Ignore it.
+        let addr = Self::read_byte(false)?;
+
+        let last = read.len() - 1;
+        for (i, byte) in read.iter_mut().enumerate() {
+            *byte = Self::read_byte(i == last)?;
+        }
+
+        defmt::debug!("R: {:02x}", read);
+
+        if send_stop {
+            defmt::debug!("R: STOP");
+            Self::stop();
+        }
+
+        Ok(())
+    }
+
+    fn write_blocking_internal(&mut self, address: u8, write: &[u8], send_stop: bool) -> Result<(), Error> {
+        if write.is_empty() {
+            return Err(Error::InvalidWriteBufferLength);
+        }
+
+        defmt::debug!("W: START");
+        Self::start(address, false, false)?;
+
+        defmt::debug!("W: {:02x}", write);
+        for byte in write.iter() {
+            Self::write_byte(*byte)?;
+        }
+
+        if send_stop {
+            defmt::debug!("W: STOP");
+            Self::stop();
+        }
+
+        Ok(())
+    }
+
+    /// Read from address into read blocking caller until done.
+    pub fn blocking_read(&mut self, address: u8, read: &mut [u8]) -> Result<(), Error> {
+        self.read_blocking_internal(address, read, false, true)
+    }
+
+    /// Write to address from write blocking caller until done.
+    pub fn blocking_write(&mut self, address: u8, write: &[u8]) -> Result<(), Error> {
+        self.write_blocking_internal(address, write, true)
+    }
+
+    /// Write to address from write and read from address into read blocking caller until done.
+    pub fn blocking_write_read(&mut self, address: u8, write: &[u8], read: &mut [u8]) -> Result<(), Error> {
+        defmt::debug!("WRITE SECTION");
+        self.write_blocking_internal(address, write, false)?;
+        defmt::debug!("READ SECTION");
+        self.read_blocking_internal(address, read, true, true)
+    }
+}
+
+impl<'d, T: Instance, M: Mode> embedded_hal_02::blocking::i2c::Read for I2c<'d, T, M> {
+    type Error = Error;
+
+    fn read(&mut self, address: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
+        self.blocking_read(address, buffer)
+    }
+}
+
+impl<'d, T: Instance, M: Mode> embedded_hal_02::blocking::i2c::Write for I2c<'d, T, M> {
+    type Error = Error;
+
+    fn write(&mut self, address: u8, bytes: &[u8]) -> Result<(), Self::Error> {
+        self.blocking_write(address, bytes)
+    }
+}
+
+impl<'d, T: Instance, M: Mode> embedded_hal_02::blocking::i2c::WriteRead for I2c<'d, T, M> {
+    type Error = Error;
+
+    fn write_read(&mut self, address: u8, bytes: &[u8], buffer: &mut [u8]) -> Result<(), Self::Error> {
+        self.blocking_write_read(address, bytes, buffer)
+    }
+}
+
+impl<'d, T: Instance, M: Mode> embedded_hal_02::blocking::i2c::Transactional for I2c<'d, T, M> {
+    type Error = Error;
+
+    fn exec(
+        &mut self,
+        address: u8,
+        operations: &mut [embedded_hal_02::blocking::i2c::Operation<'_>],
+    ) -> Result<(), Self::Error> {
+        for i in 0..operations.len() {
+            let last = i == operations.len() - 1;
+            match &mut operations[i] {
+                embedded_hal_02::blocking::i2c::Operation::Read(buf) => {
+                    self.read_blocking_internal(address, buf, false, last)?
+                }
+                embedded_hal_02::blocking::i2c::Operation::Write(buf) => {
+                    self.write_blocking_internal(address, buf, last)?
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl embedded_hal_1::i2c::Error for Error {
+    fn kind(&self) -> embedded_hal_1::i2c::ErrorKind {
+        match *self {
+            Self::Abort(AbortReason::ArbitrationLoss) => embedded_hal_1::i2c::ErrorKind::ArbitrationLoss,
+            Self::Abort(AbortReason::NoAcknowledge) => {
+                embedded_hal_1::i2c::ErrorKind::NoAcknowledge(embedded_hal_1::i2c::NoAcknowledgeSource::Address)
+            }
+            Self::Abort(AbortReason::Other) => embedded_hal_1::i2c::ErrorKind::Other,
+            Self::BusTimeout(_) => embedded_hal_1::i2c::ErrorKind::Bus,
+            Self::InvalidReadBufferLength => embedded_hal_1::i2c::ErrorKind::Other,
+            Self::InvalidWriteBufferLength => embedded_hal_1::i2c::ErrorKind::Other,
+            Self::AddressOutOfRange(_) => embedded_hal_1::i2c::ErrorKind::Other,
+            Self::AddressReserved(_) => embedded_hal_1::i2c::ErrorKind::Other,
+        }
+    }
+}
+
+impl<'d, T: Instance, M: Mode> embedded_hal_1::i2c::ErrorType for I2c<'d, T, M> {
+    type Error = Error;
+}
+
+impl<'d, T: Instance, M: Mode> embedded_hal_1::i2c::I2c for I2c<'d, T, M> {
+    fn read(&mut self, address: u8, read: &mut [u8]) -> Result<(), Self::Error> {
+        self.blocking_read(address, read)
+    }
+
+    fn write(&mut self, address: u8, write: &[u8]) -> Result<(), Self::Error> {
+        self.blocking_write(address, write)
+    }
+
+    fn write_read(&mut self, address: u8, write: &[u8], read: &mut [u8]) -> Result<(), Self::Error> {
+        self.blocking_write_read(address, write, read)
+    }
+
+    fn transaction(
+        &mut self,
+        address: u8,
+        operations: &mut [embedded_hal_1::i2c::Operation<'_>],
+    ) -> Result<(), Self::Error> {
+        for i in 0..operations.len() {
+            let last = i == operations.len() - 1;
+            match &mut operations[i] {
+                embedded_hal_1::i2c::Operation::Read(buf) => self.write_blocking_internal(address, buf, last)?,
+                embedded_hal_1::i2c::Operation::Write(buf) => self.write_blocking_internal(address, buf, last)?,
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<'d, A, T> embedded_hal_async::i2c::I2c<A> for I2c<'d, T, Async>
+where
+    A: embedded_hal_async::i2c::AddressMode + Into<u8> + 'static,
+    T: Instance + 'd,
+{
+    async fn read(&mut self, address: A, read: &mut [u8]) -> Result<(), Self::Error> {
+        self.read_async(address.into(), read).await
+    }
+
+    async fn write(&mut self, address: A, write: &[u8]) -> Result<(), Self::Error> {
+        self.write_async(address.into(), write).await
+    }
+
+    async fn write_read(&mut self, address: A, write: &[u8], read: &mut [u8]) -> Result<(), Self::Error> {
+        self.write_read_async(address.into(), write, read).await
+    }
+
+    async fn transaction(
+        &mut self,
+        address: A,
+        operations: &mut [embedded_hal_1::i2c::Operation<'_>],
+    ) -> Result<(), Self::Error> {
+        use embedded_hal_1::i2c::Operation;
+
+        let addr: u8 = address.into();
+        let mut iterator = operations.iter_mut();
+
+        while let Some(op) = iterator.next() {
+            let last = iterator.len() == 0;
+
+            match op {
+                Operation::Read(buffer) => {
+                    self.read_async_internal(addr, buffer, false, last).await?;
+                }
+                Operation::Write(buffer) => {
+                    self.write_async_internal(addr, buffer, last).await?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+trait SealedInstance {
+    fn regs() -> smb0::Smb0;
+    fn waker() -> &'static AtomicWaker;
+    fn irq_bit() -> usize;
+}
+
+trait SealedMode {}
+
+/// Drivermode.
+#[allow(private_bounds)]
+pub trait Mode: SealedMode {}
+
+macro_rules! impl_mode {
+    ($mode:ident) => {
+        impl SealedMode for $mode {}
+        impl Mode for $mode {}
+    };
+}
+
+/// Blocking mode.
+pub struct Blocking;
+
+/// Async mode.
+pub struct Async;
+
+impl_mode!(Blocking);
+impl_mode!(Async);
+
+/// I2C instance.
+#[allow(private_bounds)]
+pub trait Instance: SealedInstance + PeripheralType + 'static + Send {
+    /// Interrupt for this peripheral.
+    type Interrupt: interrupt::typelevel::Interrupt;
+}
+
+macro_rules! impl_instance {
+    ($peri:ident, $bit:expr, $irq:ident) => {
+        impl SealedInstance for peripherals::$peri {
+            #[inline(always)]
+            fn regs() -> smb0::Smb0 {
+                pac::$peri
+            }
+
+            #[inline(always)]
+            fn waker() -> &'static AtomicWaker {
+                static WAKER: AtomicWaker = AtomicWaker::new();
+                &WAKER
+            }
+
+            #[inline(always)]
+            fn irq_bit() -> usize {
+                $bit
+            }
+        }
+
+        impl Instance for peripherals::$peri {
+            type Interrupt = crate::interrupt::typelevel::$irq;
+        }
+    };
+}
+
+impl_instance!(SMB0, 0, I2CSMB0);
+impl_instance!(SMB1, 1, I2CSMB1);
+impl_instance!(SMB2, 2, I2CSMB2);
+impl_instance!(SMB3, 3, I2CSMB3);
+impl_instance!(SMB4, 4, I2CSMB4);
+
+/// SDA pin.
+pub trait SdaPin: crate::gpio::Pin {
+    fn setup(&self);
+}
+
+/// SCL pin.
+pub trait SclPin: crate::gpio::Pin {
+    fn setup(&self);
+}
+
+macro_rules! impl_pin {
+    ($function:ident, $($pin:ident, $mux:ident),*) => {
+	$(
+            impl $function for peripherals::$pin {
+		#[inline(always)]
+		fn setup(&self) {
+		    critical_section::with(|_| {
+			self.regs().ctrl1.modify(|w| {
+			    w.set_out_buff_type(crate::pac::BufferType::OPEN_DRAIN);
+			    w.set_alt_data(true);
+			    w.set_mux_ctrl(crate::pac::Function::$mux);
+			})
+		    });
+		}
+	    }
+	)*
+    };
+}
+
+#[rustfmt::skip]
+impl_pin!(
+    SdaPin,
+    GPIO0, F3,
+    GPIO3, F1,
+    GPIO5, F1,
+    GPIO7, F1,
+    GPIO12, F1,
+    GPIO26, F3,
+    GPIO30, F2,
+    GPIO66, F2,
+    GPIO70, F2,
+    GPIO72, F2,
+    GPIO130, F1,
+    GPIO132, F1,
+    GPIO141, F1,
+    GPIO143, F1,
+    GPIO145, F1,
+    GPIO147, F1,
+    GPIO152, F3,
+    GPIO154, F1
+    // GPIO231, F1 missing
+);
+
+#[rustfmt::skip]
+impl_pin!(
+    SclPin,
+    GPIO4, F1,
+    GPIO6, F1,
+    GPIO10, F1,
+    GPIO13, F1,
+    GPIO24, F3,
+    GPIO27, F3,
+    GPIO62, F2,
+    GPIO65, F2,
+    GPIO71, F2,
+    GPIO73, F2,
+    GPIO107, F4,
+    GPIO131, F1,
+    GPIO140, F1,
+    GPIO142, F1,
+    GPIO144, F4,
+    GPIO146, F1,
+    GPIO150, F1,
+    GPIO155, F1
+    // GPIO230, F1 missing
+);
+
+trait SealedValidI2cConfig {
+    fn port() -> u8;
+}
+
+/// A marker trait implemented for valid configurations
+#[allow(private_bounds)]
+pub trait ValidI2cConfig: SealedValidI2cConfig {}
+
+macro_rules! impl_config {
+    ($scl:ident, $sda:ident, $port:expr) => {
+        impl SealedValidI2cConfig for (peripherals::SMB0, peripherals::$scl, peripherals::$sda) {
+            #[inline(always)]
+            fn port() -> u8 {
+                $port
+            }
+        }
+        impl SealedValidI2cConfig for (peripherals::SMB1, peripherals::$scl, peripherals::$sda) {
+            #[inline(always)]
+            fn port() -> u8 {
+                $port
+            }
+        }
+        impl SealedValidI2cConfig for (peripherals::SMB2, peripherals::$scl, peripherals::$sda) {
+            #[inline(always)]
+            fn port() -> u8 {
+                $port
+            }
+        }
+        impl SealedValidI2cConfig for (peripherals::SMB3, peripherals::$scl, peripherals::$sda) {
+            #[inline(always)]
+            fn port() -> u8 {
+                $port
+            }
+        }
+        impl SealedValidI2cConfig for (peripherals::SMB4, peripherals::$scl, peripherals::$sda) {
+            #[inline(always)]
+            fn port() -> u8 {
+                $port
+            }
+        }
+
+        impl ValidI2cConfig for (peripherals::SMB0, peripherals::$scl, peripherals::$sda) {}
+        impl ValidI2cConfig for (peripherals::SMB1, peripherals::$scl, peripherals::$sda) {}
+        impl ValidI2cConfig for (peripherals::SMB2, peripherals::$scl, peripherals::$sda) {}
+        impl ValidI2cConfig for (peripherals::SMB3, peripherals::$scl, peripherals::$sda) {}
+        impl ValidI2cConfig for (peripherals::SMB4, peripherals::$scl, peripherals::$sda) {}
+    };
+}
+
+// I2C00
+impl_config!(GPIO4, GPIO3, 0);
+
+// I2C01
+impl_config!(GPIO73, GPIO72, 1);
+impl_config!(GPIO131, GPIO130, 1);
+
+// I2C02
+impl_config!(GPIO155, GPIO154, 2);
+
+// I2C03
+impl_config!(GPIO10, GPIO7, 3);
+
+// I2C04
+impl_config!(GPIO144, GPIO143, 4);
+
+// I2C05
+impl_config!(GPIO142, GPIO141, 5);
+
+// I2C06
+impl_config!(GPIO140, GPIO132, 6);
+
+// I2C07
+impl_config!(GPIO13, GPIO12, 7);
+impl_config!(GPIO24, GPIO152, 7);
+
+// I2C08
+// impl_config!(GPIO230, GPIO231, 8); MISSING
+
+// I2C09
+impl_config!(GPIO146, GPIO145, 9);
+
+// I2C10
+impl_config!(GPIO107, GPIO30, 10);
+
+// I2C11
+impl_config!(GPIO62, GPIO0, 11);
+impl_config!(GPIO6, GPIO5, 11);
+
+// I2C12
+impl_config!(GPIO27, GPIO26, 12);
+
+// I2C13
+impl_config!(GPIO65, GPIO66, 13);
+
+// I2C14
+impl_config!(GPIO71, GPIO70, 14);
+
+// I2C15
+impl_config!(GPIO150, GPIO147, 15);

--- a/embassy-microchip/src/i2c.rs
+++ b/embassy-microchip/src/i2c.rs
@@ -722,7 +722,7 @@ impl<'d, T: Instance + 'd, M: Mode> I2c<'d, T, M> {
         Self::start(address, true, repeated)?;
 
         // First byte in the FIFO is the slave address. Ignore it.
-        let addr = Self::read_byte(false)?;
+        let _ = Self::read_byte(false)?;
 
         let last = read.len() - 1;
         for (i, byte) in read.iter_mut().enumerate() {

--- a/embassy-microchip/src/i2c.rs
+++ b/embassy-microchip/src/i2c.rs
@@ -137,6 +137,16 @@ impl Default for Config {
     }
 }
 
+macro_rules! write_register_with_delay {
+    ($reg_path:expr, |$w:ident| $body:block) => {
+        {
+            $reg_path.write(|$w| $body);
+            // TODO - empirically determined delay
+            cortex_m::asm::delay(20_000);
+        }
+    };
+}
+
 /// I2C driver.
 pub struct I2c<'d, T: Instance, M: Mode> {
     _peri: Peri<'d, T>,
@@ -313,7 +323,7 @@ impl<'d, T: Instance> I2c<'d, T, Async> {
         }
 
         if repeated {
-            T::regs().wctrl().write(|w| {
+            write_register_with_delay!(T::regs().wctrl(), |w| {
                 w.set_eso(true);
                 w.set_sta(true);
                 w.set_ack(true);
@@ -328,7 +338,7 @@ impl<'d, T: Instance> I2c<'d, T, Async> {
                 T::regs().i2cdata().write_value(address << 1 | 0);
             }
 
-            T::regs().wctrl().write(|w| {
+            write_register_with_delay!(T::regs().wctrl(), |w| {
                 w.set_pin(true);
                 w.set_eso(true);
                 w.set_sta(true);
@@ -372,7 +382,7 @@ impl<'d, T: Instance> I2c<'d, T, Async> {
         let last = read.len() - 1;
         for (i, byte) in read.iter_mut().enumerate() {
             if i == last {
-                T::regs().wctrl().write(|w| {
+                write_register_with_delay!(T::regs().wctrl(), |w| {
                     w.set_eso(true);
                 });
             }
@@ -601,7 +611,7 @@ impl<'d, T: Instance + 'd, M: Mode> I2c<'d, T, M> {
         }
 
         if repeated {
-            T::regs().wctrl().write(|w| {
+            write_register_with_delay!(T::regs().wctrl(), |w| {
                 w.set_eso(true);
                 w.set_sta(true);
                 w.set_ack(true);
@@ -616,7 +626,7 @@ impl<'d, T: Instance + 'd, M: Mode> I2c<'d, T, M> {
                 T::regs().i2cdata().write_value(address << 1 | 0);
             }
 
-            T::regs().wctrl().write(|w| {
+            write_register_with_delay!(T::regs().wctrl(), |w| {
                 w.set_pin(true);
                 w.set_eso(true);
                 w.set_sta(true);
@@ -628,7 +638,7 @@ impl<'d, T: Instance + 'd, M: Mode> I2c<'d, T, M> {
     }
 
     fn stop() {
-        T::regs().wctrl().write(|w| {
+        write_register_with_delay!(T::regs().wctrl(), |w| {
             w.set_pin(true);
             w.set_eso(true);
             w.set_sto(true);
@@ -670,7 +680,7 @@ impl<'d, T: Instance + 'd, M: Mode> I2c<'d, T, M> {
         if !last {
             Self::check_status()?;
         } else {
-            T::regs().wctrl().write(|w| {
+            write_register_with_delay!(T::regs().wctrl(), |w| {
                 w.set_eso(true);
             });
         }
@@ -749,6 +759,8 @@ impl<'d, T: Instance + 'd, M: Mode> I2c<'d, T, M> {
     /// Write to address from write and read from address into read blocking caller until done.
     pub fn blocking_write_read(&mut self, address: u8, write: &[u8], read: &mut [u8]) -> Result<(), Error> {
         self.write_blocking_internal(address, write, false)?;
+        // TODO - empirically determined delay
+        cortex_m::asm::delay(20_000);
         self.read_blocking_internal(address, read, true, true)
     }
 }

--- a/embassy-microchip/src/i2c.rs
+++ b/embassy-microchip/src/i2c.rs
@@ -748,16 +748,24 @@ impl<'d, T: Instance + 'd, M: Mode> I2c<'d, T, M> {
 
     /// Read from address into read blocking caller until done.
     pub fn blocking_read(&mut self, address: u8, read: &mut [u8]) -> Result<(), Error> {
-        self.read_blocking_internal(address, read, false, true)
+        // TODO - empirically determined delay
+        cortex_m::asm::delay(20_000);
+        let retval = self.read_blocking_internal(address, read, false, true);
+        retval
     }
 
     /// Write to address from write blocking caller until done.
     pub fn blocking_write(&mut self, address: u8, write: &[u8]) -> Result<(), Error> {
-        self.write_blocking_internal(address, write, true)
+        // TODO - empirically determined delay
+        cortex_m::asm::delay(20_000);
+        let retval = self.write_blocking_internal(address, write, true);
+        retval
     }
 
     /// Write to address from write and read from address into read blocking caller until done.
     pub fn blocking_write_read(&mut self, address: u8, write: &[u8], read: &mut [u8]) -> Result<(), Error> {
+        // TODO - empirically determined delay
+        cortex_m::asm::delay(20_000);
         self.write_blocking_internal(address, write, false)?;
         // TODO - empirically determined delay
         cortex_m::asm::delay(20_000);

--- a/embassy-microchip/src/lib.rs
+++ b/embassy-microchip/src/lib.rs
@@ -56,7 +56,6 @@ pub mod time_driver;
 
 // Reexports
 pub use embassy_hal_internal::{Peri, PeripheralType};
-
 #[cfg(feature = "unstable-pac")]
 pub use mec17xx_pac as pac;
 #[cfg(not(feature = "unstable-pac"))]
@@ -450,7 +449,9 @@ embassy_hal_internal::peripherals! {
     GPIO226,
     GPIO227,
 
-    // Port 23 doesn't exist
+    // Port 23
+    GPIO230,
+    GPIO231,
 
     // Port 24
     GPIO240,

--- a/embassy-microchip/src/lib.rs
+++ b/embassy-microchip/src/lib.rs
@@ -50,6 +50,7 @@ compile_error!(
 pub(crate) mod fmt;
 
 pub mod gpio;
+pub mod i2c;
 pub mod pwm;
 pub mod time_driver;
 
@@ -483,6 +484,12 @@ embassy_hal_internal::peripherals! {
     PWM9,
     PWM10,
     PWM11,
+
+    SMB0,
+    SMB1,
+    SMB2,
+    SMB3,
+    SMB4,
 }
 
 /// HAL configuration for Microchip.

--- a/embassy-microchip/src/lib.rs
+++ b/embassy-microchip/src/lib.rs
@@ -1,0 +1,524 @@
+#![no_std]
+#![allow(async_fn_in_trait)]
+#![doc = include_str!("../README.md")]
+
+//! ## Feature flags
+#![doc = document_features::document_features!(feature_label = r#"<span class="stab portability"><code>{feature}</code></span>"#)]
+
+#[cfg(not(any(
+    feature = "cec1712h_b2_sx",
+    feature = "cec1712h_n2_sx",
+    feature = "cec1712h_s2_sx",
+    feature = "cec1734_s0_2hw",
+    feature = "cec1734_s0_2zw",
+    feature = "cec1736_s0_2hw",
+    feature = "cec1736_s0_2zw",
+    feature = "mec1721n_b0_lj",
+    feature = "mec1721n_b0_sz",
+    feature = "mec1723n_b0_lj",
+    feature = "mec1723n_b0_sz",
+    feature = "mec1723n_f0_sz",
+    feature = "mec1723n_p0_9y",
+    feature = "mec1724n_b0_lj",
+    feature = "mec1724n_b0_sz",
+    feature = "mec1725n_b0_lj",
+    feature = "mec1727n_b0_sz",
+)))]
+compile_error!(
+    "No chip feature activated. You must activate exactcly one of the following features:
+    cec1712h_b2_sx,
+    cec1712h_n2_sx,
+    cec1712h_s2_sx,
+    cec1734_s0_2hw,
+    cec1734_s0_2zw,
+    cec1736_s0_2hw,
+    cec1736_s0_2zw,
+    mec1721n_b0_lj,
+    mec1721n_b0_sz,
+    mec1723n_b0_lj,
+    mec1723n_b0_sz,
+    mec1723n_f0_sz,
+    mec1723n_p0_9y,
+    mec1724n_b0_lj,
+    mec1724n_b0_sz,
+    mec1725n_b0_lj,
+    mec1727n_b0_sz,
+    "
+);
+
+// This mod MUST go first, so that the others see its macros.
+pub(crate) mod fmt;
+
+pub mod gpio;
+pub mod pwm;
+pub mod time_driver;
+
+// Reexports
+pub use embassy_hal_internal::{Peri, PeripheralType};
+
+#[cfg(feature = "unstable-pac")]
+pub use mec17xx_pac as pac;
+#[cfg(not(feature = "unstable-pac"))]
+pub(crate) use mec17xx_pac as pac;
+
+#[cfg(feature = "rt")]
+pub use crate::pac::NVIC_PRIO_BITS;
+
+embassy_hal_internal::interrupt_mod!(
+    ADC_RPT,
+    ADC_SNGL,
+    AEC0_IBF,
+    AEC0_OBE,
+    AEC1_IBF,
+    AEC1_OBE,
+    AEC2_IBF,
+    AEC2_OBE,
+    AEC3_IBF,
+    AEC3_OBE,
+    AEC4_IBF,
+    AEC4_OBE,
+    APM1_CTL,
+    APM1_EN,
+    APM1_STS,
+    ASIF,
+    BCM_BUSY_CLR_0,
+    BCM_ERR_0,
+    CCT,
+    CCT_CAP0,
+    CCT_CAP1,
+    CCT_CAP2,
+    CCT_CAP3,
+    CCT_CAP4,
+    CCT_CAP5,
+    CCT_CMP0,
+    CCT_CMP1,
+    CNTR_TMR0,
+    CNTR_TMR1,
+    CNTR_TMR2,
+    CNTR_TMR3,
+    DMA_CH00,
+    DMA_CH01,
+    DMA_CH02,
+    DMA_CH03,
+    DMA_CH04,
+    DMA_CH05,
+    DMA_CH06,
+    DMA_CH07,
+    DMA_CH08,
+    DMA_CH09,
+    DMA_CH10,
+    DMA_CH11,
+    DMA_CH12,
+    DMA_CH13,
+    DMA_CH14,
+    DMA_CH15,
+    EEPROM,
+    EMI0,
+    EMI1,
+    EMI2,
+    ESPI_RESET,
+    ESPI_VWIRE,
+    GIRQ08,
+    GIRQ09,
+    GIRQ10,
+    GIRQ11,
+    GIRQ12,
+    GIRQ13,
+    GIRQ14,
+    GIRQ15,
+    GIRQ17,
+    GIRQ18,
+    GIRQ19,
+    GIRQ20,
+    GIRQ21,
+    GIRQ23,
+    GIRQ24,
+    GIRQ25,
+    GIRQ26,
+    HTMR0,
+    HTMR1,
+    I2CSMB0,
+    I2CSMB1,
+    I2CSMB2,
+    I2CSMB3,
+    I2CSMB4,
+    INTR_BM1,
+    INTR_BM2,
+    INTR_FLASH,
+    INTR_LTR,
+    INTR_OOB_DOWN,
+    INTR_OOB_UP,
+    INTR_PC,
+    KBC_IBF,
+    KBC_OBE,
+    KEYSCAN,
+    LED0,
+    LED1,
+    LED2,
+    LED3,
+    MBOX,
+    P80CAP0,
+    PECI,
+    PHOT,
+    POWERGUARD_0,
+    POWERGUARD_1,
+    PS2_0A_WAKE,
+    PS2_0B_WAKE,
+    PS2_0_ACT,
+    QMSPI,
+    RC_ID0,
+    RC_ID1,
+    RC_ID2,
+    RPM2PWM_0_SPIN,
+    RPM2PWM_0_STALL,
+    RPM2PWM_1_SPIN,
+    RPM2PWM_1_STALL,
+    RTC,
+    RTC_ALARM,
+    RTMR,
+    RX0,
+    RX1,
+    SAF_DONE,
+    SAF_ERR,
+    SPISLV,
+    SYSPWR,
+    TACH0,
+    TACH1,
+    TACH2,
+    TACH3,
+    TIMER16_0,
+    TIMER16_1,
+    TIMER16_2,
+    TIMER16_3,
+    TIMER32_0,
+    TIMER32_1,
+    TX0,
+    TX1,
+    UART0,
+    UART1,
+    VCI_IN0,
+    VCI_IN1,
+    VCI_IN2,
+    VCI_IN3,
+    VCI_OVRD_IN,
+    WDT,
+    WK,
+    WKSEC,
+    WKSUB,
+    WKSUBSEC,
+);
+
+/// Macro to bind interrupts to handlers.
+///
+/// This defines the right interrupt handlers, and creates a unit struct (like `struct Irqs;`)
+/// and implements the right [`Binding`]s for it. You can pass this struct to drivers to
+/// prove at compile-time that the right interrupts have been bound.
+///
+/// Example of how to bind one interrupt:
+///
+/// ```rust,ignore
+/// use embassy_rp::{bind_interrupts, usb, peripherals};
+///
+/// bind_interrupts!(struct Irqs {
+///     USBCTRL_IRQ => usb::InterruptHandler<peripherals::USB>;
+/// });
+/// ```
+///
+// developer note: this macro can't be in `embassy-hal-internal` due to the use of `$crate`.
+#[macro_export]
+macro_rules! bind_interrupts {
+    ($vis:vis struct $name:ident {
+        $(
+            $(#[cfg($cond_irq:meta)])?
+            $irq:ident => $(
+                $(#[cfg($cond_handler:meta)])?
+                $handler:ty
+            ),*;
+        )*
+    }) => {
+        #[derive(Copy, Clone)]
+        $vis struct $name;
+
+        $(
+            #[allow(non_snake_case)]
+            #[no_mangle]
+            $(#[cfg($cond_irq)])?
+            unsafe extern "C" fn $irq() {
+                $(
+                    $(#[cfg($cond_handler)])?
+                    <$handler as $crate::interrupt::typelevel::Handler<$crate::interrupt::typelevel::$irq>>::on_interrupt();
+
+                )*
+            }
+
+            $(#[cfg($cond_irq)])?
+            $crate::bind_interrupts!(@inner
+                $(
+                    $(#[cfg($cond_handler)])?
+                    unsafe impl $crate::interrupt::typelevel::Binding<$crate::interrupt::typelevel::$irq, $handler> for $name {}
+                )*
+            );
+        )*
+    };
+    (@inner $($t:tt)*) => {
+        $($t)*
+    }
+}
+
+embassy_hal_internal::peripherals! {
+    // Port 0
+    GPIO0,
+    GPIO1,
+    GPIO2,
+    GPIO3,
+    GPIO4,
+    GPIO5,
+    GPIO6,
+    GPIO7,
+
+    // Port 1
+    GPIO10,
+    GPIO11,
+    GPIO12,
+    GPIO13,
+    GPIO14,
+    GPIO15,
+    GPIO16,
+    GPIO17,
+
+    // Port 2
+    GPIO20,
+    GPIO21,
+    GPIO22,
+    GPIO23,
+    GPIO24,
+    GPIO25,
+    GPIO26,
+    GPIO27,
+
+    // Port 3
+    GPIO30,
+    GPIO31,
+    GPIO32,
+    GPIO33,
+    GPIO34,
+    GPIO35,
+    GPIO36,
+
+    // Port 4
+    GPIO40,
+    GPIO41,
+    GPIO42,
+    GPIO43,
+    GPIO44,
+    GPIO45,
+    GPIO46,
+    GPIO47,
+
+    // Port 5
+    GPIO50,
+    GPIO51,
+    GPIO52,
+    GPIO53,
+    GPIO54,
+    GPIO55,
+    GPIO56,
+    GPIO57,
+
+    // Port 6
+    GPIO60,
+    GPIO61,
+    GPIO62,
+    GPIO63,
+    GPIO64,
+    GPIO65,
+    GPIO66,
+    GPIO67,
+
+    // Port 7
+    GPIO70,
+    GPIO71,
+    GPIO72,
+    GPIO73,
+    GPIO74,
+    GPIO75,
+    GPIO76,
+
+    // Ports 8 and 9 don't exist
+
+    // Port 10
+    GPIO100,
+    GPIO101,
+    GPIO102,
+    GPIO103,
+    GPIO104,
+    GPIO105,
+    GPIO106,
+    GPIO107,
+
+    // Port 11
+    GPIO112,
+    GPIO113,
+    GPIO114,
+    GPIO115,
+    GPIO116,
+    GPIO117,
+
+    // Port 12
+    GPIO120,
+    GPIO121,
+    GPIO122,
+    GPIO123,
+    GPIO124,
+    GPIO125,
+    GPIO126,
+    GPIO127,
+
+    // Port 13
+    GPIO130,
+    GPIO131,
+    GPIO132,
+    GPIO133,
+    GPIO134,
+    GPIO135,
+
+    // Port 14
+    GPIO140,
+    GPIO141,
+    GPIO142,
+    GPIO143,
+    GPIO144,
+    GPIO145,
+    GPIO146,
+    GPIO147,
+
+    // Port 15
+    GPIO150,
+    GPIO151,
+    GPIO152,
+    GPIO153,
+    GPIO154,
+    GPIO155,
+    GPIO156,
+    GPIO157,
+
+    // Port 16
+    GPIO160,
+    GPIO161,
+    GPIO162,
+    GPIO165,
+    GPIO166,
+    GPIO167,
+
+    // Port 17
+    GPIO170,
+    GPIO171,
+    GPIO172,
+    GPIO173,
+    GPIO174,
+    GPIO175,
+
+    // Ports 18 and 19 don't exist
+
+    // Port 20
+    GPIO200,
+    GPIO201,
+    GPIO202,
+    GPIO203,
+    GPIO204,
+    GPIO205,
+    GPIO206,
+    GPIO207,
+
+    // Port 21
+    GPIO210,
+    GPIO211,
+    GPIO212,
+    GPIO213,
+    GPIO214,
+    GPIO215,
+    GPIO216,
+    GPIO217,
+
+    // Port 22
+    GPIO221,
+    GPIO222,
+    GPIO223,
+    GPIO224,
+    GPIO225,
+    GPIO226,
+    GPIO227,
+
+    // Port 23 doesn't exist
+
+    // Port 24
+    GPIO240,
+    GPIO241,
+    GPIO242,
+    GPIO243,
+    GPIO244,
+    GPIO245,
+    GPIO246,
+    GPIO247,
+
+    // Port 25
+    // GPIO253, no interrupt
+    GPIO254,
+    GPIO255,
+    // GPIO256, no interrupt
+    // GPIO257, no interrupt
+
+    // Port 26
+    // GPIO260, no interrupt
+
+    PWM0,
+    PWM1,
+    PWM2,
+    PWM3,
+    PWM4,
+    PWM5,
+    PWM6,
+    PWM7,
+    PWM8,
+    PWM9,
+    PWM10,
+    PWM11,
+}
+
+/// HAL configuration for Microchip.
+pub mod config {
+    /// HAL configuration passed when initializing.
+    #[non_exhaustive]
+    pub struct Config {}
+
+    impl Default for Config {
+        fn default() -> Self {
+            Self {}
+        }
+    }
+
+    impl Config {
+        /// Create a new configuration
+        pub fn new() -> Self {
+            Self {}
+        }
+    }
+}
+
+/// Initialize the `embassy-microchip` HAL with the provided configuration.
+///
+/// This returns the peripheral singletons that can be used for creating drivers.
+///
+/// This should only be called once at startup, otherwise it panis.
+pub fn init(_config: config::Config) -> Peripherals {
+    let peripherals = Peripherals::take();
+
+    unsafe {
+        // ROM code leaves interrupts globally disabled, d'oh.
+        cortex_m::interrupt::enable();
+        gpio::init();
+    }
+    time_driver::init();
+
+    peripherals
+}

--- a/embassy-microchip/src/pwm.rs
+++ b/embassy-microchip/src/pwm.rs
@@ -1,0 +1,226 @@
+//! Pulse Width Modulation (PWM)
+
+use embassy_hal_internal::{Peri, PeripheralType};
+pub use embedded_hal_1::pwm::SetDutyCycle;
+use embedded_hal_1::pwm::{Error, ErrorKind, ErrorType};
+
+use crate::gpio::{AnyPin, Pin as GpioPin};
+use crate::pac::pwm0::Pwm0;
+use crate::{pac, peripherals};
+
+#[allow(non_camel_case_types)]
+#[derive(Copy, Clone, PartialEq)]
+/// Clock selection
+pub enum Clock {
+    _48MHz,
+    _100kHz,
+}
+
+impl From<Clock> for bool {
+    fn from(clk: Clock) -> Self {
+        match clk {
+            Clock::_48MHz => true,
+            Clock::_100kHz => false,
+        }
+    }
+}
+
+/// The configuration of a PWM slice.
+#[non_exhaustive]
+#[derive(Clone, Copy)]
+pub struct Config {
+    /// Inverts the PWM output signal.
+    pub invert: bool,
+
+    /// Enables the PWM slice, allowing it to generate an output.
+    pub enable: bool,
+
+    /// PWM target frequency
+    pub frequency: u32,
+
+    /// PWM target duty cycle
+    pub duty_cycle: u16,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            invert: false,
+            enable: true, // differs from reset
+            frequency: 100_000,
+            duty_cycle: 32767,
+        }
+    }
+}
+
+/// PWM error.
+#[derive(Debug)]
+pub enum PwmError {
+    /// Invalid Duty Cycle.
+    InvalidDutyCycle,
+}
+
+impl Error for PwmError {
+    fn kind(&self) -> ErrorKind {
+        match self {
+            PwmError::InvalidDutyCycle => ErrorKind::Other,
+        }
+    }
+}
+
+/// PWM driver.
+pub struct Pwm<'d, T: Instance> {
+    _peri: Peri<'d, T>,
+    _pin: Peri<'d, AnyPin>,
+}
+
+impl<'d, T: Instance> ErrorType for Pwm<'d, T> {
+    type Error = PwmError;
+}
+
+impl<'d, T: Instance> Pwm<'d, T> {
+    const HIGHEST_DIVIDER: u32 = 15;
+    const HIGHEST_ON_OFF: u32 = 65_535;
+    const HIGH_CLK_FREQ: u32 = 48_000_000;
+    const LOW_CLK_FREQ: u32 = 100_000;
+    const MIN_HIGH_CLK_FREQ: u32 = Self::HIGH_CLK_FREQ / (2 * (Self::HIGHEST_ON_OFF + 1) * (Self::HIGHEST_DIVIDER + 1));
+
+    pub fn new(peri: Peri<'d, T>, pin: Peri<'d, impl PwmPin<T>>, config: Config) -> Self {
+        Self::new_inner(peri, pin, config)
+    }
+
+    fn new_inner(_peri: Peri<'d, T>, _pin: Peri<'d, impl PwmPin<T>>, config: Config) -> Self {
+        // REVISIT: make an API for this
+        critical_section::with(|_| {
+            _pin.regs().ctrl1.modify(|w| {
+                w.set_mux_ctrl(pac::Function::F1);
+            })
+        });
+
+        Self::configure(config);
+        Self {
+            _peri,
+            _pin: _pin.into(),
+        }
+    }
+
+    fn configure(config: Config) {
+        let (div, on, off, clk) = Self::compute_parameters(config.frequency, config.duty_cycle);
+
+        T::regs().cfg().write(|w| {
+            w.set_inv(config.invert);
+            w.set_clk_sel(clk.into());
+            w.set_clk_pre_div(div);
+            w.set_pwm_en(config.enable);
+        });
+
+        T::regs().cnt_on().write_value(on);
+        T::regs().cnt_off().write_value(off);
+    }
+
+    fn compute_parameters(target_freq: u32, target_duty_cycle: u16) -> (u8, u32, u32, Clock) {
+        let high = target_freq > Self::MIN_HIGH_CLK_FREQ;
+
+        // We assume that if target_freq is not greater than high
+        // clock minimum frequency, then it must fit within the low
+        // clock, even if with high error.
+
+        let (clk, freq) = if high {
+            (Clock::_48MHz, Self::HIGH_CLK_FREQ)
+        } else {
+            (Clock::_100kHz, Self::LOW_CLK_FREQ)
+        };
+
+        let (div, _) = (1..=16).fold((0, u32::MAX), |(best_div, best_error), d| {
+            let candidate = freq / d;
+            let error = target_freq.abs_diff(candidate);
+
+            if error < best_error {
+                (candidate, error)
+            } else {
+                (best_div, best_error)
+            }
+        });
+
+        let (on, off) = Self::compute_on_off(freq, target_freq, target_duty_cycle);
+        (div as u8, on, off, clk)
+    }
+
+    fn compute_on_off(freq: u32, target_freq: u32, target_duty_cycle: u16) -> (u32, u32) {
+        let total = freq * 10 / target_freq;
+        let on = ((total * u32::from(target_duty_cycle)) / 100_000) - 1;
+        let off = total - on - 2;
+
+        (on, off)
+    }
+}
+
+impl<'d, T: Instance> SetDutyCycle for Pwm<'d, T> {
+    fn max_duty_cycle(&self) -> u16 {
+        u16::MAX
+    }
+
+    fn set_duty_cycle(&mut self, duty: u16) -> Result<(), Self::Error> {
+        let max_duty = self.max_duty_cycle();
+
+        if duty > max_duty {
+            return Err(PwmError::InvalidDutyCycle);
+        }
+
+        let off = u32::from(duty) * u32::from(u16::MAX) / u32::from(max_duty);
+        let on = u32::from(u16::MAX) - off;
+
+        T::regs().cnt_on().write_value(on.into());
+        T::regs().cnt_off().write_value(off.into());
+
+        Ok(())
+    }
+}
+
+trait SealedInstance {
+    fn regs() -> Pwm0;
+}
+
+/// PWM Instance trait
+#[allow(private_bounds)]
+pub trait Instance: SealedInstance + PeripheralType + 'static + Send {}
+
+macro_rules! impl_instance {
+    ($($peri:ident),*) => {
+	$(
+	    impl SealedInstance for peripherals::$peri {
+		#[inline(always)]
+		fn regs() -> Pwm0 {
+		    pac::$peri
+		}
+	    }
+
+	    impl Instance for peripherals::$peri {}
+	)*
+    }
+}
+
+impl_instance!(PWM0, PWM1, PWM2, PWM3, PWM4, PWM5, PWM6, PWM7, PWM8, PWM9, PWM10, PWM11);
+
+pub trait PwmPin<T: Instance>: GpioPin + PeripheralType {}
+
+macro_rules! impl_pin {
+    ($peri:ident, $($pin:ident),*) => {
+	$(
+	    impl PwmPin<peripherals::$peri> for peripherals::$pin {}
+	)*
+    }
+}
+
+impl_pin!(PWM0, GPIO53, GPIO241);
+impl_pin!(PWM1, GPIO54);
+impl_pin!(PWM2, GPIO55, GPIO45);
+impl_pin!(PWM3, GPIO56);
+impl_pin!(PWM4, GPIO11, GPIO1);
+impl_pin!(PWM5, GPIO2);
+impl_pin!(PWM6, GPIO14, GPIO63);
+impl_pin!(PWM7, GPIO15);
+impl_pin!(PWM8, GPIO35, GPIO175);
+impl_pin!(PWM9, GPIO133);
+impl_pin!(PWM10, GPIO134);
+impl_pin!(PWM11, GPIO160, GPIO222);

--- a/embassy-microchip/src/time_driver.rs
+++ b/embassy-microchip/src/time_driver.rs
@@ -1,0 +1,204 @@
+//! Time driver.
+use core::cell::{Cell, RefCell};
+use core::sync::atomic::{compiler_fence, AtomicU32, Ordering};
+
+use critical_section::CriticalSection;
+use embassy_hal_internal::interrupt::InterruptExt;
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_sync::blocking_mutex::CriticalSectionMutex as Mutex;
+use embassy_time_driver::Driver;
+use embassy_time_queue_utils::Queue;
+
+use crate::interrupt;
+use crate::pac::{CCT, ECIA};
+
+/// Calculate the timestamp from the period count and the tick count.
+///
+/// The Input Capture and Compare Timer is a 32-bit free running timer
+/// running at the main clock frequency.
+///
+/// We define a period to be 2^31 ticks, such that each overflow is 2
+/// periods.
+///
+/// Toe get `now()`, `period` is read first, then `counter` is
+/// read. If the counter value matches the expected range for the
+/// `period` parity, we're done. If it doesn't, this mean that a new
+/// period start has raced us between reading `period` and `counter`,
+/// so we assume the `counter` value corresponds to the next period.
+///
+/// `period` is a 32-bit integer, it overlows on 2^32 * 2^31 /
+/// 48_000_000 seconds of uptime, which is about 6093 years.
+fn calc_now(period: u32, counter: u32) -> u64 {
+    ((period as u64) << 31) + ((counter ^ ((period & 1) << 31)) as u64)
+}
+
+struct AlarmState {
+    timestamp: Cell<u64>,
+}
+
+unsafe impl Send for AlarmState {}
+
+impl AlarmState {
+    const fn new() -> Self {
+        Self {
+            timestamp: Cell::new(u64::MAX),
+        }
+    }
+}
+
+pub(crate) struct CctDriver {
+    /// Number of 2^31 periods elapsed since boot.
+    period: AtomicU32,
+
+    /// Timestamp at which to fire alarm. `u64::MAX` if no alarm is
+    /// scheduled.
+    alarm: Mutex<AlarmState>,
+    queue: Mutex<RefCell<Queue>>,
+}
+
+embassy_time_driver::time_driver_impl!(static DRIVER: CctDriver = CctDriver {
+    period: AtomicU32::new(0),
+    alarm: Mutex::const_new(CriticalSectionRawMutex::new(), AlarmState::new()),
+    queue: Mutex::new(RefCell::new(Queue::new())),
+});
+
+impl CctDriver {
+    fn init(&'static self) {
+        interrupt::CCT.disable();
+        interrupt::CCT_CMP0.disable();
+        interrupt::CCT_CMP1.disable();
+
+        interrupt::CCT.set_priority(interrupt::Priority::P0);
+        interrupt::CCT_CMP0.set_priority(interrupt::Priority::P0);
+        interrupt::CCT_CMP1.set_priority(interrupt::Priority::P0);
+
+        ECIA.src18().write_value(1 << 20 | 1 << 27 | 1 << 28);
+        ECIA.en_set18().write_value(1 << 20 | 1 << 27 | 1 << 28);
+
+        // Reset timer
+        CCT.ctrl().write(|w| w.set_free_rst(true));
+
+        // Wait until reset is completed
+        while CCT.ctrl().read().free_rst() {}
+
+        // Mid
+        CCT.comp0().write(|w| w.set_comp_0(0x8000_0000));
+
+        CCT.ctrl().write(|w| {
+            w.set_act(true);
+            w.set_free_en(true);
+            w.set_cmp_en0(true);
+        });
+
+        interrupt::CCT.unpend();
+        interrupt::CCT_CMP0.unpend();
+        interrupt::CCT_CMP1.unpend();
+        unsafe {
+            interrupt::CCT.enable();
+            interrupt::CCT_CMP0.enable();
+            interrupt::CCT_CMP1.enable();
+        }
+    }
+
+    fn next_period(&self) {
+        let period = self.period.load(Ordering::Relaxed) + 1;
+        self.period.store(period, Ordering::Relaxed);
+        let t = (period as u64) << 31;
+
+        critical_section::with(move |cs| {
+            let alarm = self.alarm.borrow(cs);
+            let at = alarm.timestamp.get();
+
+            if at < t + 0xc000_0000 {
+                CCT.ctrl().modify(|w| w.set_cmp_en1(true));
+            }
+        });
+    }
+
+    fn set_alarm(&self, cs: CriticalSection, timestamp: u64) -> bool {
+        self.alarm.borrow(cs).timestamp.set(timestamp);
+
+        let t = self.now();
+        if timestamp <= t {
+            // If timestamp has passed, alarm will not fire.
+            // Disarm it and return `false`.
+            CCT.ctrl().modify(|w| w.set_cmp_en1(false));
+            self.alarm.borrow(cs).timestamp.set(u64::MAX);
+            return false;
+        }
+
+        CCT.comp1().write(|w| w.set_comp_1(timestamp as u32));
+
+        let diff = timestamp - t;
+        CCT.ctrl().modify(|w| w.set_cmp_en1(diff < 0xc000_0000));
+
+        let t = self.now();
+        if timestamp <= t {
+            CCT.ctrl().modify(|w| w.set_cmp_en1(true));
+            // If timestamp has passed, alarm will not fire.
+            // Disarm it and return `false`.
+            CCT.ctrl().modify(|w| w.set_cmp_en1(false));
+            self.alarm.borrow(cs).timestamp.set(u64::MAX);
+            return false;
+        }
+
+        true
+    }
+
+    fn trigger_alarm(&self, cs: CriticalSection) {
+        let mut next = self.queue.borrow(cs).borrow_mut().next_expiration(self.now());
+        while !self.set_alarm(cs, next) {
+            next = self.queue.borrow(cs).borrow_mut().next_expiration(self.now());
+        }
+    }
+}
+
+impl Driver for CctDriver {
+    fn now(&self) -> u64 {
+        let period = self.period.load(Ordering::Relaxed);
+        compiler_fence(Ordering::Acquire);
+        let counter = CCT.free_run().read().tmr();
+        calc_now(period, counter)
+    }
+
+    fn schedule_wake(&self, at: u64, waker: &core::task::Waker) {
+        critical_section::with(|cs| {
+            let mut queue = self.queue.borrow(cs).borrow_mut();
+
+            if queue.schedule_wake(at, waker) {
+                let mut next = queue.next_expiration(self.now());
+                while !self.set_alarm(cs, next) {
+                    next = queue.next_expiration(self.now());
+                }
+            }
+        })
+    }
+}
+
+#[cfg(feature = "time-driver-cct")]
+#[cfg(feature = "rt")]
+#[interrupt]
+fn CCT() {
+    ECIA.src18().write_value(1 << 20);
+    DRIVER.next_period();
+}
+
+#[cfg(feature = "time-driver-cct")]
+#[cfg(feature = "rt")]
+#[interrupt]
+fn CCT_CMP0() {
+    ECIA.src18().write_value(1 << 27);
+    DRIVER.next_period();
+}
+
+#[cfg(feature = "time-driver-cct")]
+#[cfg(feature = "rt")]
+#[interrupt]
+fn CCT_CMP1() {
+    ECIA.src18().write_value(1 << 28);
+    critical_section::with(|cs| DRIVER.trigger_alarm(cs));
+}
+
+pub(crate) fn init() {
+    DRIVER.init()
+}

--- a/examples/microchip/.cargo/config.toml
+++ b/examples/microchip/.cargo/config.toml
@@ -1,0 +1,17 @@
+[target.thumbv7em-none-eabihf]
+runner = 'probe-rs run --chip MEC1723N_B0_SZ'
+
+rustflags = [
+  # "-C", "linker=flip-link",
+  "-C", "link-arg=-Tlink_ram.x",
+  "-C", "link-arg=-Tdefmt.x",
+  # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x
+  # See https://github.com/rust-embedded/cortex-m-quickstart/pull/95
+  "-C", "link-arg=--nmagic",
+]
+
+[build]
+target = "thumbv7em-none-eabihf" # Cortex-M4F
+
+[env]
+DEFMT_LOG = "trace"

--- a/examples/microchip/Cargo.toml
+++ b/examples/microchip/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "microchip-blinky"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+cortex-m = { version = "0.7.7", features = ["critical-section-single-core", "inline-asm"] }
+cortex-m-rt = "0.7.5"
+defmt = "1.0"
+defmt-rtt = "1.0"
+embassy-executor = { version = "0.7.0", path = "../../embassy-executor", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
+embassy-microchip = { path = "../../embassy-microchip", features = ["mec1723n_b0_sz", "rt", "defmt", "unstable-pac", "time-driver-cct"] }
+embassy-time = { version = "0.4.0", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime"] }
+panic-probe = { version = "0.3.2", features = ["print-defmt"] }

--- a/examples/microchip/build.rs
+++ b/examples/microchip/build.rs
@@ -1,0 +1,26 @@
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+fn main() {
+    // Put `memory.x` in our output directory and ensure it's
+    // on the linker search path.
+    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    File::create(out.join("link_ram.x"))
+        .unwrap()
+        .write_all(include_bytes!("link_ram.x"))
+        .unwrap();
+    File::create(out.join("memory.x"))
+        .unwrap()
+        .write_all(include_bytes!("memory.x"))
+        .unwrap();
+    println!("cargo:rustc-link-search={}", out.display());
+
+    // By default, Cargo will re-run a build script whenever
+    // any file in the project changes. By specifying `memory.x`
+    // here, we ensure the build script is only re-run when
+    // `memory.x` is changed.
+    println!("cargo:rerun-if-changed=memory.x");
+    println!("cargo:rerun-if-changed=link_ram.x");
+}

--- a/examples/microchip/link_ram.x
+++ b/examples/microchip/link_ram.x
@@ -1,0 +1,280 @@
+/* ##### EMBASSY NOTE
+    Originally from https://github.com/rust-embedded/cortex-m/blob/master/cortex-m-rt/link.x.in
+    Adjusted to put everything in RAM
+*/
+
+/* # Developer notes
+
+- Symbols that start with a double underscore (__) are considered "private"
+
+- Symbols that start with a single underscore (_) are considered "semi-public"; they can be
+  overridden in a user linker script, but should not be referred from user code (e.g. `extern "C" {
+  static mut __sbss }`).
+
+- `EXTERN` forces the linker to keep a symbol in the final binary. We use this to make sure a
+  symbol if not dropped if it appears in or near the front of the linker arguments and "it's not
+  needed" by any of the preceding objects (linker arguments)
+
+- `PROVIDE` is used to provide default values that can be overridden by a user linker script
+
+- On alignment: it's important for correctness that the VMA boundaries of both .bss and .data *and*
+  the LMA of .data are all 4-byte aligned. These alignments are assumed by the RAM initialization
+  routine. There's also a second benefit: 4-byte aligned boundaries means that you won't see
+  "Address (..) is out of bounds" in the disassembly produced by `objdump`.
+*/
+
+/* Provides information about the memory layout of the device */
+/* This will be provided by the user (see `memory.x`) or by a Board Support Crate */
+INCLUDE memory.x
+
+/* # Entry point = reset vector */
+EXTERN(__RESET_VECTOR);
+EXTERN(Reset);
+ENTRY(Reset);
+
+/* # Exception vectors */
+/* This is effectively weak aliasing at the linker level */
+/* The user can override any of these aliases by defining the corresponding symbol themselves (cf.
+   the `exception!` macro) */
+EXTERN(__EXCEPTIONS); /* depends on all the these PROVIDED symbols */
+
+EXTERN(DefaultHandler);
+
+PROVIDE(NonMaskableInt = DefaultHandler);
+EXTERN(HardFaultTrampoline);
+PROVIDE(MemoryManagement = DefaultHandler);
+PROVIDE(BusFault = DefaultHandler);
+PROVIDE(UsageFault = DefaultHandler);
+PROVIDE(SecureFault = DefaultHandler);
+PROVIDE(SVCall = DefaultHandler);
+PROVIDE(DebugMonitor = DefaultHandler);
+PROVIDE(PendSV = DefaultHandler);
+PROVIDE(SysTick = DefaultHandler);
+
+PROVIDE(DefaultHandler = DefaultHandler_);
+PROVIDE(HardFault = HardFault_);
+
+/* # Interrupt vectors */
+EXTERN(__INTERRUPTS); /* `static` variable similar to `__EXCEPTIONS` */
+
+/* # Pre-initialization function */
+/* If the user overrides this using the `pre_init!` macro or by creating a `__pre_init` function,
+   then the function this points to will be called before the RAM is initialized. */
+PROVIDE(__pre_init = DefaultPreInit);
+
+/* # Sections */
+SECTIONS
+{
+  PROVIDE(_ram_start = ORIGIN(RAM));
+  PROVIDE(_ram_end = ORIGIN(RAM) + LENGTH(RAM));
+  PROVIDE(_stack_start = _ram_end);
+
+  /* ## Sections in RAM */
+  /* ### Vector table */
+  .vector_table ORIGIN(RAM) :
+  {
+    __vector_table = .;
+
+    /* Initial Stack Pointer (SP) value.
+     * We mask the bottom three bits to force 8-byte alignment.
+     * Despite having an assert for this later, it's possible that a separate
+     * linker script could override _stack_start after the assert is checked.
+     */
+    LONG(_stack_start & 0xFFFFFFF8);
+
+    /* Reset vector */
+    KEEP(*(.vector_table.reset_vector)); /* this is the `__RESET_VECTOR` symbol */
+
+    /* Exceptions */
+    __exceptions = .; /* start of exceptions */
+    KEEP(*(.vector_table.exceptions)); /* this is the `__EXCEPTIONS` symbol */
+    __eexceptions = .; /* end of exceptions */
+
+    /* Device specific interrupts */
+    KEEP(*(.vector_table.interrupts)); /* this is the `__INTERRUPTS` symbol */
+  } > RAM
+
+  PROVIDE(_stext = ADDR(.vector_table) + SIZEOF(.vector_table));
+
+  /* ### .text */
+  .text _stext :
+  {
+    __stext = .;
+    *(.Reset);
+
+    *(.text .text.*);
+
+    /* The HardFaultTrampoline uses the `b` instruction to enter `HardFault`,
+       so must be placed close to it. */
+    *(.HardFaultTrampoline);
+    *(.HardFault.*);
+
+    . = ALIGN(4); /* Pad .text to the alignment to workaround overlapping load section bug in old lld */
+    __etext = .;
+  } > RAM
+
+  /* ### .rodata */
+  .rodata : ALIGN(4)
+  {
+    . = ALIGN(4);
+    __srodata = .;
+    *(.rodata .rodata.*);
+
+    /* 4-byte align the end (VMA) of this section.
+       This is required by LLD to ensure the LMA of the following .data
+       section will have the correct alignment. */
+    . = ALIGN(4);
+    __erodata = .;
+  } > RAM
+
+  /* ## Sections in RAM */
+  /* ### .data */
+  .data : ALIGN(4)
+  {
+    . = ALIGN(4);
+    __sdata = .;
+    __edata = .; /* RAM: By setting __sdata=__edata cortex-m-rt has to copy 0 bytes as .data is already in RAM */
+
+    *(.data .data.*);
+    . = ALIGN(4); /* 4-byte align the end (VMA) of this section */
+  } > RAM
+  /* Allow sections from user `memory.x` injected using `INSERT AFTER .data` to
+   * use the .data loading mechanism by pushing __edata. Note: do not change
+   * output region or load region in those user sections! */
+  /* Link from RAM: Disabled, now __sdata == __edata
+  . = ALIGN(4);
+  __edata = .;
+  */
+
+  /* LMA of .data */
+  __sidata = LOADADDR(.data);
+
+  /* ### .gnu.sgstubs
+     This section contains the TrustZone-M veneers put there by the Arm GNU linker. */
+  /* Security Attribution Unit blocks must be 32 bytes aligned. */
+  /* Note that this pads the RAM usage to 32 byte alignment. */
+  .gnu.sgstubs : ALIGN(32)
+  {
+    . = ALIGN(32);
+    __veneer_base = .;
+    *(.gnu.sgstubs*)
+    . = ALIGN(32);
+  } > RAM
+  /* Place `__veneer_limit` outside the `.gnu.sgstubs` section because veneers are
+   * always inserted last in the section, which would otherwise be _after_ the `__veneer_limit` symbol.
+   */
+  . = ALIGN(32);
+  __veneer_limit = .;
+
+  /* ### .bss */
+  .bss (NOLOAD) : ALIGN(4)
+  {
+    . = ALIGN(4);
+    __sbss = .;
+    *(.bss .bss.*);
+    *(COMMON); /* Uninitialized C statics */
+    . = ALIGN(4); /* 4-byte align the end (VMA) of this section */
+  } > RAM
+  /* Allow sections from user `memory.x` injected using `INSERT AFTER .bss` to
+   * use the .bss zeroing mechanism by pushing __ebss. Note: do not change
+   * output region or load region in those user sections! */
+  . = ALIGN(4);
+  __ebss = .;
+
+  /* ### .uninit */
+  .uninit (NOLOAD) : ALIGN(4)
+  {
+    . = ALIGN(4);
+    __suninit = .;
+    *(.uninit .uninit.*);
+    . = ALIGN(4);
+    __euninit = .;
+  } > RAM
+
+  /* Place the heap right after `.uninit` in RAM */
+  PROVIDE(__sheap = __euninit);
+
+  /* ## .got */
+  /* Dynamic relocations are unsupported. This section is only used to detect relocatable code in
+     the input files and raise an error if relocatable code is found */
+  .got (NOLOAD) :
+  {
+    KEEP(*(.got .got.*));
+  }
+
+  /* ## Discarded sections */
+  /DISCARD/ :
+  {
+    /* Unused exception related info that only wastes space */
+    *(.ARM.exidx);
+    *(.ARM.exidx.*);
+    *(.ARM.extab.*);
+  }
+}
+
+/* Do not exceed this mark in the error messages below                                    | */
+/* # Alignment checks */
+ASSERT(ORIGIN(RAM) % 4 == 0, "
+ERROR(cortex-m-rt): the start of the RAM region must be 4-byte aligned");
+
+ASSERT(__sdata % 4 == 0 && __edata % 4 == 0, "
+BUG(cortex-m-rt): .data is not 4-byte aligned");
+
+ASSERT(__sidata % 4 == 0, "
+BUG(cortex-m-rt): the LMA of .data is not 4-byte aligned");
+
+ASSERT(__sbss % 4 == 0 && __ebss % 4 == 0, "
+BUG(cortex-m-rt): .bss is not 4-byte aligned");
+
+ASSERT(__sheap % 4 == 0, "
+BUG(cortex-m-rt): start of .heap is not 4-byte aligned");
+
+ASSERT(_stack_start % 8 == 0, "
+ERROR(cortex-m-rt): stack start address is not 8-byte aligned.
+If you have set _stack_start, check it's set to an address which is a multiple of 8 bytes.
+If you haven't, stack starts at the end of RAM by default. Check that both RAM
+origin and length are set to multiples of 8 in the `memory.x` file.");
+
+/* # Position checks */
+
+/* ## .vector_table
+ *
+ * If the *start* of exception vectors is not 8 bytes past the start of the
+ * vector table, then we somehow did not place the reset vector, which should
+ * live 4 bytes past the start of the vector table.
+ */
+ASSERT(__exceptions == ADDR(.vector_table) + 0x8, "
+BUG(cortex-m-rt): the reset vector is missing");
+
+ASSERT(__eexceptions == ADDR(.vector_table) + 0x40, "
+BUG(cortex-m-rt): the exception vectors are missing");
+
+ASSERT(SIZEOF(.vector_table) > 0x40, "
+ERROR(cortex-m-rt): The interrupt vectors are missing.
+Possible solutions, from most likely to less likely:
+- Link to a svd2rust generated device crate
+- Check that you actually use the device/hal/bsp crate in your code
+- Disable the 'device' feature of cortex-m-rt to build a generic application (a dependency
+may be enabling it)
+- Supply the interrupt handlers yourself. Check the documentation for details.");
+
+/* ## .text */
+ASSERT(ADDR(.vector_table) + SIZEOF(.vector_table) <= _stext, "
+ERROR(cortex-m-rt): The .text section can't be placed inside the .vector_table section
+Set _stext to an address greater than the end of .vector_table (See output of `nm`)");
+
+ASSERT(_stext + SIZEOF(.text) < ORIGIN(RAM) + LENGTH(RAM), "
+ERROR(cortex-m-rt): The .text section must be placed inside the RAM memory.
+Set _stext to an address smaller than 'ORIGIN(RAM) + LENGTH(RAM)'");
+
+/* # Other checks */
+ASSERT(SIZEOF(.got) == 0, "
+ERROR(cortex-m-rt): .got section detected in the input object files
+Dynamic relocations are not supported. If you are linking to C code compiled using
+the 'cc' crate then modify your build script to compile the C code _without_
+the -fPIC flag. See the documentation of the `cc::Build.pic` method for details.");
+/* Do not exceed this mark in the error messages above                                    | */
+
+/* Provides weak aliases (cf. PROVIDED) for device specific interrupt handlers */
+/* This will usually be provided by a device crate generated using svd2rust (see `device.x`) */
+INCLUDE device.x

--- a/examples/microchip/memory.x
+++ b/examples/microchip/memory.x
@@ -1,0 +1,3 @@
+MEMORY {
+	RAM      : ORIGIN = 0x000c0000, LENGTH = 384K
+}

--- a/examples/microchip/src/bin/blinky.rs
+++ b/examples/microchip/src/bin/blinky.rs
@@ -1,0 +1,30 @@
+#![no_main]
+#![no_std]
+
+use defmt::info;
+use embassy_executor::Spawner;
+use embassy_microchip::gpio::{Level, Output};
+use embassy_time::Timer;
+use {defmt_rtt as _, panic_probe as _};
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    unsafe {
+        let cp = cortex_m::Peripherals::steal();
+        cp.SCB.vtor.write(0x000c_0000);
+    }
+
+    let p = embassy_microchip::init(Default::default());
+
+    info!("Hello, world!");
+
+    let mut led1 = Output::new(p.GPIO157, Level::Low);
+    let mut led2 = Output::new(p.GPIO153, Level::High);
+
+    loop {
+        info!("toggle leds");
+        led1.toggle();
+        led2.toggle();
+        Timer::after_secs(1).await;
+    }
+}

--- a/examples/microchip/src/bin/button-async.rs
+++ b/examples/microchip/src/bin/button-async.rs
@@ -1,0 +1,23 @@
+#![no_main]
+#![no_std]
+
+use defmt::info;
+use embassy_executor::Spawner;
+use embassy_microchip::gpio::{Input, Pull};
+use {defmt_rtt as _, panic_probe as _};
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    info!("Hello, world!");
+    let p = embassy_microchip::init(Default::default());
+    let mut btn = Input::new(p.GPIO141, Pull::None);
+
+    loop {
+        if btn.is_high() {
+            info!("Press button...");
+        } else {
+            info!("Release button...");
+        }
+        btn.wait_for_any_edge().await;
+    }
+}

--- a/examples/microchip/src/bin/button.rs
+++ b/examples/microchip/src/bin/button.rs
@@ -1,0 +1,21 @@
+#![no_main]
+#![no_std]
+
+use defmt::info;
+use embassy_executor::Spawner;
+use embassy_microchip::gpio::{Input, Pull};
+use embassy_time::Timer;
+use {defmt_rtt as _, panic_probe as _};
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let p = embassy_microchip::init(Default::default());
+
+    info!("Hello, world!");
+    let btn = Input::new(p.GPIO141, Pull::None);
+
+    loop {
+        info!("Button State: {}", btn.get_level());
+        Timer::after_secs(1).await;
+    }
+}

--- a/examples/microchip/src/bin/i2c.rs
+++ b/examples/microchip/src/bin/i2c.rs
@@ -1,0 +1,36 @@
+#![no_main]
+#![no_std]
+
+use defmt::info;
+use embassy_executor::Spawner;
+use embassy_microchip::i2c::I2c;
+use embassy_time::Timer;
+use {defmt_rtt as _, panic_probe as _};
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    unsafe {
+        let cp = cortex_m::Peripherals::steal();
+        cp.SCB.vtor.write(0x000c_0000);
+    }
+
+    let p = embassy_microchip::init(Default::default());
+
+    info!("Hello, world!");
+
+    let mut i2c = I2c::new_blocking(p.SMB0, p.GPIO73, p.GPIO72, Default::default());
+
+    Timer::after_secs(1).await;
+
+    let mut read = [0_u8; 1];
+
+    loop {
+        for addr in (0..0x7f_u8).into_iter() {
+            if i2c.blocking_read(addr, &mut read).is_ok() {
+                info!("Found device at addr {:02x}", addr);
+            }
+        }
+
+        Timer::after_secs(1).await;
+    }
+}

--- a/examples/microchip/src/bin/pwm.rs
+++ b/examples/microchip/src/bin/pwm.rs
@@ -1,0 +1,36 @@
+#![no_main]
+#![no_std]
+
+use defmt::info;
+use embassy_executor::Spawner;
+use embassy_microchip::gpio::{Input, Pull};
+use embassy_microchip::pwm::{Pwm, SetDutyCycle};
+use {defmt_rtt as _, panic_probe as _};
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    unsafe {
+        let cp = cortex_m::Peripherals::steal();
+        cp.SCB.vtor.write(0x000c_0000);
+    }
+
+    let p = embassy_microchip::init(Default::default());
+
+    info!("Hello, world!");
+
+    let mut pwm = Pwm::new(p.PWM0, p.GPIO53, Default::default());
+    let mut btn = Input::new(p.GPIO141, Pull::None);
+
+    let max_duty = pwm.max_duty_cycle();
+    let step = max_duty / 10;
+
+    loop {
+        for duty in (1..max_duty).step_by(step.into()) {
+            pwm.set_duty_cycle(duty).unwrap();
+
+            info!("Duty cycle sent to {}. Press button for next step...", duty);
+            btn.wait_for_low().await;
+            btn.wait_for_high().await;
+        }
+    }
+}


### PR DESCRIPTION
FYI only - I'm not a fan of this change but it does resolve the hang and bogus second byte problem when accessing a tmp117 temperature sensor from i2c0 on the MEC1723 EVB.